### PR TITLE
fix(youtube-publishing): fix license typo

### DIFF
--- a/project/backend/apps/aitoearn-channel/src/core/publishing/dto/publish.dto.ts
+++ b/project/backend/apps/aitoearn-channel/src/core/publishing/dto/publish.dto.ts
@@ -58,7 +58,7 @@ export enum YouTubePrivacyStatus {
 }
 
 export enum YouTubeLicense {
-  CreativeCommons = 'creativeCommons',
+  CreativeCommon = 'creativeCommon',
   YouTube = 'youtube',
 }
 


### PR DESCRIPTION
fix youtube license typo
# Pull Request

## 🧩 Issue Link

<!--
Required: Please link at least one Issue.
Closing keywords: Closes #123 / Fixes #123 / Resolves #123
Reference only: Related to #123 / Refs #123
Multiple links supported: Closes #12, Related to #34
Cross-repo: Closes owner/repo#123
-->

Closes #219 

## 📝 Description
fix youtube license typo: CreativeCommons -> CreativeCommon
<!-- Briefly describe the purpose of this PR and the main changes introduced. -->


