### PR TITLE
fix: action card persistence and chat status improvements

### DIFF
--- a/project/web/src/app/i18n/locales/en/settings.json
+++ b/project/web/src/app/i18n/locales/en/settings.json
@@ -42,6 +42,7 @@
     "usageRecords": "Usage Records",
     "detail": "Detail",
     "date": "Date",
+    "amount": "Amount",
     "amountChange": "Amount Change",
     "noRecords": "No usage records yet",
     "loading": "Loading...",

--- a/project/web/src/app/i18n/locales/zh-CN/settings.json
+++ b/project/web/src/app/i18n/locales/zh-CN/settings.json
@@ -42,6 +42,7 @@
     "usageRecords": "使用记录",
     "detail": "详情",
     "date": "日期",
+    "amount": "金额",
     "amountChange": "金额变更",
     "noRecords": "暂无使用记录",
     "loading": "加载中...",

--- a/project/web/src/components/SettingsModal/tabs/SubscriptionTab.tsx
+++ b/project/web/src/components/SettingsModal/tabs/SubscriptionTab.tsx
@@ -248,64 +248,67 @@ export function SubscriptionTab() {
           {t('subscription.usageRecords')}
         </h4>
 
-        {/* 表头 - 移动端隐藏日期列 */}
-        <div className="grid grid-cols-2 gap-2 border-b border-border px-2 pb-3 text-xs font-medium text-muted-foreground md:grid-cols-12 md:gap-4">
-          <div className="md:col-span-6">{t('subscription.detail')}</div>
-          <div className="hidden md:col-span-3 md:block">{t('subscription.date')}</div>
-          <div className="text-right md:col-span-3">{t('subscription.amountChange')}</div>
-        </div>
+        {/* 表格容器 */}
+        <div className="w-full">
+          {/* 表头 */}
+          <div className="flex items-center border-b border-border px-2 pb-3 text-xs font-medium text-muted-foreground">
+            <div className="min-w-0 flex-1">{t('subscription.detail')}</div>
+            <div className="hidden w-[140px] shrink-0 text-right md:block">{t('subscription.date')}</div>
+            <div className="w-[70px] shrink-0 text-right md:w-[90px]">{t('subscription.amount')}</div>
+          </div>
 
-        {/* 记录列表 */}
-        <div className="divide-y divide-border">
-          {recordsLoading
-            ? (
-                // 骨架屏
-                Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className="grid grid-cols-2 gap-2 px-2 py-3 md:grid-cols-12 md:gap-4">
-                    <div className="md:col-span-6">
-                      <Skeleton className="h-4 w-3/4" />
-                    </div>
-                    <div className="hidden md:col-span-3 md:block">
-                      <Skeleton className="h-4 w-full" />
-                    </div>
-                    <div className="flex justify-end md:col-span-3">
-                      <Skeleton className="h-4 w-16" />
-                    </div>
-                  </div>
-                ))
-              )
-            : records.length === 0
+          {/* 记录列表 */}
+          <div className="divide-y divide-border">
+            {recordsLoading
               ? (
-                  <div className="py-8 text-center text-sm text-muted-foreground">
-                    {t('subscription.noRecords')}
-                  </div>
-                )
-              : (
-                  records.map(record => (
-                    <div
-                      key={record.id}
-                      className="grid grid-cols-2 gap-2 px-2 py-3 text-sm md:grid-cols-12 md:gap-4"
-                    >
-                      {/* 详情 */}
-                      <div className="min-w-0 truncate text-foreground md:col-span-6">
-                        {record.description || t(`subscription.types.${record.type}`)}
+                  // 骨架屏
+                  Array.from({ length: 5 }).map((_, i) => (
+                    <div key={i} className="flex items-center px-2 py-3">
+                      <div className="min-w-0 flex-1">
+                        <Skeleton className="h-4 w-3/4" />
                       </div>
-                      {/* 日期 - 移动端隐藏 */}
-                      <div className="hidden text-muted-foreground md:col-span-3 md:block">
-                        {formatDate(record.createdAt)}
+                      <div className="hidden w-[140px] shrink-0 md:block">
+                        <Skeleton className="ml-auto h-4 w-24" />
                       </div>
-                      {/* 金额变更 */}
-                      <div
-                        className={cn(
-                          'text-right font-medium md:col-span-3',
-                          record.amount >= 0 ? 'text-green-600' : 'text-foreground',
-                        )}
-                      >
-                        {formatAmountChange(record.amount)}
+                      <div className="w-[70px] shrink-0 md:w-[90px]">
+                        <Skeleton className="ml-auto h-4 w-12" />
                       </div>
                     </div>
                   ))
-                )}
+                )
+              : records.length === 0
+                ? (
+                    <div className="py-8 text-center text-sm text-muted-foreground">
+                      {t('subscription.noRecords')}
+                    </div>
+                  )
+                : (
+                    records.map(record => (
+                      <div
+                        key={record.id}
+                        className="flex items-center px-2 py-3 text-sm"
+                      >
+                        {/* 详情 */}
+                        <div className="min-w-0 flex-1 truncate text-foreground">
+                          {record.description || t(`subscription.types.${record.type}`)}
+                        </div>
+                        {/* 日期 - 移动端隐藏 */}
+                        <div className="hidden w-[140px] shrink-0 text-right text-muted-foreground md:block">
+                          {formatDate(record.createdAt)}
+                        </div>
+                        {/* 金额变更 */}
+                        <div
+                          className={cn(
+                            'w-[70px] shrink-0 text-right font-medium tabular-nums md:w-[90px]',
+                            record.amount >= 0 ? 'text-green-600' : 'text-foreground',
+                          )}
+                        >
+                          {formatAmountChange(record.amount)}
+                        </div>
+                      </div>
+                    ))
+                  )}
+          </div>
         </div>
 
         {/* 分页器 */}

--- a/project/web/src/lib/utils.ts
+++ b/project/web/src/lib/utils.ts
@@ -6,9 +6,9 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * 格式化相对时间
- * @param date 日期对象或时间戳
- * @returns 格式化后的相对时间字符串
+ * Format relative time
+ * @param date Date object or timestamp
+ * @returns Formatted relative time string
  */
 export function formatRelativeTime(date: Date | number): string {
   const now = new Date()
@@ -20,13 +20,13 @@ export function formatRelativeTime(date: Date | number): string {
   const diffDay = Math.floor(diffHour / 24)
 
   if (diffSec < 60) {
-    return '刚刚'
+    return 'Just now'
   } else if (diffMin < 60) {
-    return `${diffMin}分钟前`
+    return `${diffMin}m ago`
   } else if (diffHour < 24) {
-    return `${diffHour}小时前`
+    return `${diffHour}h ago`
   } else if (diffDay < 7) {
-    return `${diffDay}天前`
+    return `${diffDay}d ago`
   } else {
     const year = target.getFullYear()
     const month = String(target.getMonth() + 1).padStart(2, '0')


### PR DESCRIPTION
- Fix action card not persisting: parse result.action from root level (msg.result)
- Fix chat end status: updateMessageActions now sets status to 'done'
- Add TaskStatus.RequiresAction enum for requires_action status
- Improve TaskCard with status-specific colors and icons
- Add i18n for task status labels (zh-CN/en)
- Update taskStatus.ts to recognize requires_action as completed

# Pull Request

## 🧩 Issue Link

<!--
Required: Please link at least one Issue.
Closing keywords: Closes #123 / Fixes #123 / Resolves #123
Reference only: Related to #123 / Refs #123
Multiple links supported: Closes #12, Related to #34
Cross-repo: Closes owner/repo#123
-->
Related to #400 


## 📝 Description

<!-- Briefly describe the purpose of this PR and the main changes introduced. -->


