### PR TITLE
Add Japanese (ja-JP) language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Required Node.JS 20.18.x](https://img.shields.io/static/v1?label=node&message=20.18.x&logo=node.js&color=3f893e)](https://nodejs.org/about/releases)
 
-简体中文 | [English](README_EN.md)
+简体中文 | [English](README_EN.md) | [日本語](README_JA.md)
 
 **Monetize · Publish · Engage · Create —— 一站式平台。**
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Required Node.JS 20.18.x](https://img.shields.io/static/v1?label=node&message=20.18.x&logo=node.js&color=3f893e)](https://nodejs.org/about/releases)
 
-English | [简体中文](README.md)
+English | [简体中文](README.md) | [日本語](README_JA.md)
 
 **Monetize · Publish · Engage · Create — all in one platform.**
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,332 @@
+# [Aitoearn：個人ビジネス向けAIコンテンツマーケティングエージェント](https://aitoearn.ai)
+
+<a href="https://trendshift.io/repositories/20785" target="_blank"><img src="https://trendshift.io/api/badge/repositories/20785" alt="yikart%2FAiToEarn | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+[![GitHub stars](https://img.shields.io/github/stars/yikart/AiToEarn?color=fa6470)](https://github.com/yikart/AiToEarn/stargazers)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Required Node.JS 20.18.x](https://img.shields.io/static/v1?label=node&message=20.18.x&logo=node.js&color=3f893e)](https://nodejs.org/about/releases)
+
+日本語 | [简体中文](README.md) | [English](README_EN.md)
+
+**収益化 · 公開 · エンゲージメント · クリエイト —— オールインワンプラットフォーム。**
+
+AiToEarnは**AI自動化**を通じて、クリエイター、ブランド、企業が世界中の主要プラットフォームでコンテンツを構築、配信、収益化するのを支援します。
+
+対応チャンネル：
+抖音（Douyin）、小紅書（Rednote）、快手（Kuaishou）、bilibili、TikTok、YouTube、Facebook、Instagram、Threads、Twitter（X）、Pinterest、LinkedIn
+
+## 🚀 AiToEarnをすぐに使う（5つの方法）
+
+| 方法 | 対象 | デプロイ必要？ |
+|------|------|--------------|
+| [① ウェブサイトで直接使う](#use-web) | すべてのユーザー | ❌ 不要 |
+| [② OpenClaw（ロブスター）で使う](#use-in-openclaw) | OpenClawユーザー | ❌ 不要 |
+| [③ Claude / Cursor などのAIアシスタントで使う](#use-in-claude) | AIツールユーザー | ❌ 不要 |
+| [④ Dockerワンクリックデプロイ](#use-docker) | 自己デプロイしたいチーム | ✅ サーバー必要 |
+| [⑤ ソースコードから開発](#use-source) | 開発者 | ✅ 開発環境必要 |
+
+> 💡 **方法②③④は事前にAPI Keyの取得が必要です**。[API Keyの取得方法](#get-api-key)を先にご覧ください。
+
+## 最新情報
+
+- **2026-03-26**: [2.1バージョン](https://www.aitoearn.ai/) — 多くの使いやすさの問題を修正。OpenClaw（ロブスター）対応を追加し、OpenClaw内で直接AiToEarnを使用可能に。MCPプロトコル対応を追加し、Claude、CursorなどMCP対応のエージェントやLLMでAiToEarnを使用可能に。
+- **2025-02-07**: [1.8.0バージョン](https://www.aitoearn.ai/) — オフライン店舗プロモーションソリューションを追加。レストラン、小売店、民宿、美容室、ジムなど多様なオフラインビジネスに対応。オフラインのプロモーション活動を実行可能なオンライン拡散タスクに変換し、コンテンツ公開とユーザー参加メカニズムを通じて店舗のオンライン露出と来店トラフィックの増加を支援。
+- **2025-01-06**: [1.5.3バージョン](https://www.aitoearn.ai/) — 多数の既知の問題を修正
+- **2024-12-15**: 「All In Agent」の始まり！コンテンツの自動生成・公開、そしてAitoearnの操作を支援するスーパーAIエージェントを追加。[v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/v1.4.3)
+- **2024-11-28**: アプリ内自動更新に対応。作成画面に多くのAI機能を追加：要約、拡張、画像生成、動画生成、タグ生成など。Nano Banana Proにも対応。[v1.4.0](https://github.com/yikart/AiToEarn/releases/tag/v1.4.0)
+- **2024-11-12**: 初のオープンソースで完全に使用可能なバージョン。[v1.3.2](https://github.com/yikart/AiToEarn/releases/tag/v1.3.2)
+
+<details>
+  <summary><h2 style="display:inline;margin:0">目次</h2></summary>
+
+  <br/>
+
+  1. [AiToEarnをすぐに使う（5つの方法）](#-aitoearnをすぐに使う5つの方法)
+  2. [最新情報](#最新情報)
+  3. [主な機能](#主な機能)
+  4. [API Keyの取得方法](#get-api-key)
+  5. [貢献ガイド](#貢献ガイド)
+  6. [お問い合わせ](#お問い合わせ)
+  7. [推奨](#推奨)
+</details>
+
+## 主な機能
+
+AiToEarnはコンテンツクリエイターの完全な収益化パイプラインを中心に、4つのエージェント機能を提供します：
+
+> **収益化 · 公開 · エンゲージメント · クリエイト**
+
+---
+
+### 💰 収益化 —— コンテンツで稼ぐ
+
+AiToEarnの最も重要な目標：**すべてのクリエイターが稼げるようにする**。
+
+クリエイターはプラットフォーム上でコンテンツを販売し、ブランドのプロモーションタスクを完了できます。すべての決済は成果報酬型で、3つの決済モードを提供：
+
+| 決済モード | 正式名称 | 意味 |
+|---------|------|------|
+| **CPS** | Cost Per Sale | 売上額に基づいて決済 |
+| **CPE** | Cost Per Engagement | エンゲージメント数に基づいて決済 |
+| **CPM** | Cost Per Mille | 再生数に基づいて決済 |
+
+<div style="display: flex; justify-content: space-around;">
+  <img src="presentation/monetize-cn.png" width="50%">
+</div>
+
+---
+
+### 📢 公開 —— コンテンツ公開エージェント
+
+ワンクリックで世界中の10以上の主要プラットフォームにコンテンツを配信。各プラットフォームで手動投稿する手間から解放されます。
+
+- **マルチプラットフォーム配信**：抖音、快手、B站、小紅書、TikTok、YouTube、Facebook、Instagram、Threads、X（Twitter）、Pinterest、LinkedInに対応
+- **カレンダースケジュール**：カレンダーのように全プラットフォームのコンテンツ公開時間を統一的に計画
+
+<div style="display: flex; justify-content: space-around;">
+  <img src="presentation/publish-cn.png" width="30%">
+  <img src="presentation/app-screenshot/1.%20content%20publish/support_channels.jpeg" width="30%">
+</div>
+
+> ▶ デモ動画を見る
+
+<a href="https://www.youtube.com/watch?v=5041jEKaiU8">
+  <img src="https://img.youtube.com/vi/5041jEKaiU8/0.jpg" alt="公開 デモ動画" width="480">
+</a>
+
+---
+
+### 💬 エンゲージメント —— コンテンツ交流エージェント
+
+AiToEarnブラウザ拡張機能を通じて、上記のすべてのプラットフォームで自動化された交流運用を実現。
+
+- **自動化アクション**：自動いいね、保存、フォロー — 大規模な一括操作
+- **AIスマート返信**：LLMを使用して各コメントに的確な返信を生成
+- **コメントマイニング**：「リンクください」「購入方法は」などの高コンバージョンシグナルを検出し、即座に対応
+- **ブランドモニタリング**：ブランドに関する言及をリアルタイムで追跡し、トレンドの会話に積極的に参加
+
+> ▶ デモ動画を見る
+
+<a href="https://youtu.be/-QoHNrZBmp0">
+  <img src="./presentation/engage-thumbnail-cn.png" alt="エンゲージメント デモ動画" width="480">
+</a>
+
+---
+
+### 🎨 クリエイト —— コンテンツ作成エージェント
+
+エージェント方式でコンテンツ制作ワークフローを再構築しました。エージェントにコンテンツのニーズを伝えるだけで、アイデアから完成品まで全てを自動的に処理します。
+
+**動画コンテンツ**：エージェントが自動的に動画生成モデル（Grok、Veo、Seedanceなど）、動画翻訳モジュール、動画編集モジュールを呼び出し、一貫して動画を制作。
+
+**画像・テキストコンテンツ**：Nano Bananaなどのトップクラスの画像モデルをサポートし、高品質なビジュアルコンテンツを自動生成。
+
+**一括生成**：作成タスクを一括で投入 — エージェントが複数のコンテンツを並列生成。マトリックスアカウント運用や大規模コンテンツ配信に最適。
+
+> ▶ デモ動画を見る
+
+<a href="https://youtu.be/y900LxIrZT4">
+  <img src="./presentation/display-1.5.2png.png" alt="クリエイト デモ動画" width="480">
+</a>
+
+---
+
+<h2 id="use-web">① ウェブサイトで直接使う</h2>
+
+最も簡単な方法 — ブラウザを開くだけで使用可能：
+
+- 🇨🇳 中国のユーザー：**[aitoearn.cn](https://aitoearn.cn/)**
+- 🌍 その他のユーザー：**[aitoearn.ai](https://aitoearn.ai/)**
+
+---
+
+<h2 id="get-api-key">🔑 API Keyの取得方法（以下の手順に必要）</h2>
+
+> 以下の方法②③④にはAPI Keyが必要です。一度取得すれば、すべての方法で使用可能です。
+
+**3ステップで取得**：
+
+1. [aitoearn.cn](https://aitoearn.cn/)（中国）または[aitoearn.ai](https://aitoearn.ai/)（その他）を開き、登録・ログイン
+2. 左メニューの**設定**をクリック
+3. **API Key**に移動し、作成をクリックして、生成されたキーをコピー
+
+<img src="presentation/app-screenshot/0.%20api-key/api-key-settings.png" alt="API Key取得" width="600">
+
+> ⚠️ API Keyは安全に保管し、他人に共有しないでください。
+
+---
+
+<h2 id="use-in-openclaw">② OpenClaw（ロブスター）で使う</h2>
+
+> 前提条件：[API Keyを取得済み](#get-api-key)
+
+ワンステップ — 以下のメッセージをOpenClawに送信（`あなたのAPI-Key`をご自身のものに置き換え）：
+
+> mcporterを使ってこのMCPサーバーをインストールしてください：`https://aitoearn.ai/api/unified/mcp`、認証ヘッダーは `x-api-key: あなたのAPI-Key`
+
+OpenClawが自動的にセットアップを完了します。その後、「小紅書に投稿して」などの指示を直接OpenClawに伝えるだけで使えます。
+
+---
+
+<h2 id="use-in-claude">③ Claude / Cursor / その他のAIアシスタントで使う</h2>
+
+> 前提条件：[API Keyを取得済み](#get-api-key)
+
+AiToEarnはMCPプロトコルに対応するすべてのAIアシスタントで動作します。一般的なツールの設定方法：
+
+<details open>
+<summary><b>Claude Desktop</b></summary>
+
+`claude_desktop_config.json`を見つけて編集し、以下を追加：
+
+```json
+{
+  "mcpServers": {
+    "aitoearn": {
+      "type": "http",
+      "url": "https://aitoearn.ai/api/unified/mcp",
+      "headers": {
+        "x-api-key": "あなたのAPI-Key"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+CursorのMCP設定で以下を追加：
+
+```
+MCP URL: https://aitoearn.ai/api/unified/mcp
+認証ヘッダー: x-api-key: あなたのAPI-Key
+```
+
+</details>
+
+<details>
+<summary><b>その他のAIアシスタント（汎用設定）</b></summary>
+
+MCPプロトコル対応のツールなら、2つの情報だけでOK：
+
+| 設定項目 | 値 |
+|--------|------|
+| **MCP URL** | `https://aitoearn.ai/api/unified/mcp` |
+| **認証ヘッダー** | `x-api-key: あなたのAPI-Key` |
+
+SSE接続もサポート：`https://aitoearn.ai/api/unified/sse`
+
+</details>
+
+> 💡 自己デプロイの場合は、`aitoearn.ai`をご自身のアドレス（例：`localhost:8080`）に置き換えてください。
+
+---
+
+<h2 id="use-docker">④ Dockerワンクリックデプロイ</h2>
+
+> 前提条件：[Docker](https://docs.docker.com/get-docker/)がインストール済み
+
+自分のサーバーでAiToEarnを運用したいチーム向け。3つのコマンドで完了、データベースの手動インストール不要：
+
+```bash
+git clone https://github.com/yikart/AiToEarn.git
+cd AiToEarn
+docker compose up -d
+```
+
+起動後、**[http://localhost:8080](http://localhost:8080)** を開けば使用可能。
+
+#### Relayの設定（強く推奨）
+
+> **なぜRelayが必要？** コンテンツを公開するにはソーシャルメディアアカウント（TikTok、Instagram、YouTubeなど）へのログインが必要で、これらのプラットフォームのOAuthログインには開発者認証情報が必要です。Relayを設定すれば、公式aitoearn.aiの認証情報を直接借用して認証を完了できるため、**各プラットフォームで開発者アカウントを申請する必要がありません**。
+
+`docker-compose.yml`の`aitoearn-server`サービスに以下を追加（API Keyの取得方法は[上記](#get-api-key)を参照）：
+
+```yaml
+RELAY_SERVER_URL: https://aitoearn.ai/api
+RELAY_API_KEY: あなたのAPI-Key
+RELAY_CALLBACK_URL: http://127.0.0.1:8080/api/plat/relay-callback
+```
+
+その後再起動：`docker compose restart aitoearn-server`
+
+> 📖 完全なデプロイガイド（本番環境設定、AIサービス、OAuth、ストレージなど）：[DOCKER_DEPLOYMENT_EN.md](DOCKER_DEPLOYMENT_EN.md)を参照。
+
+---
+
+<h2 id="use-source">⑤ ソースコードから開発</h2>
+
+<details>
+<summary>🧪 バックエンドとフロントエンドを手動で実行（開発モード）</summary>
+
+このモードは主にローカル開発とデバッグ用です。
+Dockerを使用してMongoDB/Redisを実行するか、設定ファイルで独自のサービスを指定できます。
+
+#### 1. バックエンドサービスを起動
+
+```bash
+cd project/aitoearn-backend
+pnpm install
+# ローカル開発用設定ファイルをコピー
+cp apps/aitoearn-ai/config/config.js apps/aitoearn-ai/config/local.config.js
+cp apps/aitoearn-server/config/config.js apps/aitoearn-server/config/local.config.js
+pnpm nx serve aitoearn-ai
+# 別のターミナルで
+pnpm nx serve aitoearn-server
+```
+
+#### 2. フロントエンド `aitoearn-web` を起動
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+</details>
+
+<details>
+<summary>🖥️ Electronデスクトッププロジェクトを起動</summary>
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/yikart/AttAiToEarn.git
+
+# ディレクトリに移動
+cd AttAiToEarn
+
+# 依存関係をインストール
+npm install
+
+# sqliteをコンパイル（better-sqlite3にはnode-gypとローカルPythonが必要）
+npm run rebuild
+
+# 開発を起動
+npm run dev
+```
+
+ElectronプロジェクトはAiToEarnのデスクトップクライアントを提供します。
+
+</details>
+
+## 貢献ガイド
+
+参加するには[貢献ガイド](./CONTRIBUTING.md)をご覧ください。
+
+## お問い合わせ
+
+- Telegram: [https://t.me/harryyyy2025](https://t.me/harryyyy2025)
+- WeChat：QRコードをスキャンして追加
+
+<img src="presentation/wechat.jpg" alt="WeChat QRコード" width="200">
+
+## 推奨
+
+- [MuseTalk](https://github.com/TMElyralab/MuseTalk)
+- [video_spider](https://github.com/5ime/video_spider)
+- [CosyVoice](https://github.com/FunAudioLLM/CosyVoice?tab=readme-ov-file)
+- [facefusion](https://github.com/facefusion/facefusion)
+- [NarratoAI](https://github.com/linyqh/NarratoAI)
+- [MoneyPrinterTurbo](https://github.com/harry0703/MoneyPrinterTurbo)

--- a/project/aitoearn-backend/libs/common/src/i18n/messages.ts
+++ b/project/aitoearn-backend/libs/common/src/i18n/messages.ts
@@ -1,7 +1,7 @@
 import template from 'art-template'
 import { ResponseCode } from '../enums'
 
-export type Locale = 'en-US' | 'zh-CN'
+export type Locale = 'en-US' | 'zh-CN' | 'ja-JP'
 
 // 消息可以是字符串或预编译的模板函数
 type MessageValue = string | ((data: unknown) => string
@@ -10,309 +10,378 @@ export const messages: Record<ResponseCode, Record<Locale, MessageValue>> = {
   [ResponseCode.Success]: {
     'en-US': 'Success',
     'zh-CN': '请求成功',
+    'ja-JP': '成功しました',
   },
 
   // 10000 (common)
   [ResponseCode.MailSendFail]: {
     'en-US': 'Failed to send email',
     'zh-CN': '邮件发送失败',
+    'ja-JP': 'メールの送信に失敗しました',
   },
   [ResponseCode.ValidationFailed]: {
     'en-US': 'Validation failed',
     'zh-CN': '参数验证失败',
+    'ja-JP': 'バリデーションに失敗しました',
   },
   [ResponseCode.TooManyRequests]: {
     'en-US': template.compile('Too many requests, please try again after {{ttl}} seconds'),
     'zh-CN': template.compile('请求过于频繁，请在{{ttl}}秒后重试'),
+    'ja-JP': template.compile('リクエストが多すぎます。{{ttl}}秒後にお試しください'),
   },
   [ResponseCode.SmsSendFail]: {
     'en-US': 'Failed to send SMS',
     'zh-CN': '短信发送失败',
+    'ja-JP': 'SMSの送信に失敗しました',
   },
 
   // 10100 (s3)
   [ResponseCode.S3DownloadFileFailed]: {
     'en-US': 'Failed to download file from S3',
     'zh-CN': 'S3 文件下载失败',
+    'ja-JP': 'S3からのファイルダウンロードに失敗しました',
   },
 
   // 12000 (user)
   [ResponseCode.UserNotFound]: {
     'en-US': 'User not found',
     'zh-CN': '用户未找到',
+    'ja-JP': 'ユーザーが見つかりません',
   },
   [ResponseCode.UserCreditsInsufficient]: {
     'en-US': 'Insufficient user credits',
     'zh-CN': '用户Credits不足',
+    'ja-JP': 'クレジットが不足しています',
   },
   [ResponseCode.UserStatusError]: {
     'en-US': 'User status error',
     'zh-CN': '用户状态错误',
+    'ja-JP': 'ユーザーステータスエラー',
   },
   [ResponseCode.UserLoginCodeError]: {
     'en-US': 'Incorrect login code',
     'zh-CN': '登录验证码错误',
+    'ja-JP': 'ログインコードが正しくありません',
   },
 
   // 12300 (ai)
   [ResponseCode.InvalidModel]: {
     'en-US': 'Invalid AI model',
     'zh-CN': '无效的 AI 模型',
+    'ja-JP': '無効なAIモデルです',
   },
   [ResponseCode.AiCallFailed]: {
     'en-US': template.compile('AI call failed: {{error}}'),
     'zh-CN': template.compile('AI 调用失败：{{error}}'),
+    'ja-JP': template.compile('AI呼び出しに失敗しました：{{error}}'),
   },
   [ResponseCode.InvalidAiTaskId]: {
     'en-US': 'Invalid AI task ID',
     'zh-CN': '无效的 AI 任务 ID',
+    'ja-JP': '無効なAIタスクIDです',
   },
   [ResponseCode.AiLogNotFound]: {
     'en-US': 'AI log not found',
     'zh-CN': 'AI 日志未找到',
+    'ja-JP': 'AIログが見つかりません',
   },
   [ResponseCode.VideoUploadVidNotFound]: {
     'en-US': 'Failed to get video ID from upload result',
     'zh-CN': '从上传结果中获取视频 ID 失败',
+    'ja-JP': 'アップロード結果から動画IDを取得できませんでした',
   },
   [ResponseCode.VideoUploadFailed]: {
     'en-US': 'Video upload task failed',
     'zh-CN': '视频上传任务失败',
+    'ja-JP': '動画アップロードタスクに失敗しました',
   },
 
   // 12400 (notification)
   [ResponseCode.NotificationNotFound]: {
     'en-US': 'Notification not found',
     'zh-CN': '通知未找到',
+    'ja-JP': '通知が見つかりません',
   },
 
   // 12600 (account)
   [ResponseCode.AccountNotFound]: {
     'en-US': 'Account not found',
     'zh-CN': '账号未找到',
+    'ja-JP': 'アカウントが見つかりません',
   },
   [ResponseCode.AccountGroupNotFound]: {
     'en-US': 'Account group not found',
     'zh-CN': '账号分组未找到',
+    'ja-JP': 'アカウントグループが見つかりません',
   },
   [ResponseCode.AccountCreateFailed]: {
     'en-US': 'Account create failed',
     'zh-CN': '账号创建失败',
+    'ja-JP': 'アカウントの作成に失敗しました',
   },
 
   // 12700 (media)
   [ResponseCode.MediaNotFound]: {
     'en-US': 'Media not found',
     'zh-CN': '媒体文件未找到',
+    'ja-JP': 'メディアファイルが見つかりません',
   },
   [ResponseCode.MediaGroupNotFound]: {
     'en-US': 'Media group not found',
     'zh-CN': '媒体分组未找到',
+    'ja-JP': 'メディアグループが見つかりません',
   },
   [ResponseCode.MediaGroupDefaultNotAllowed]: {
     'en-US': 'Default media group cannot be deleted',
     'zh-CN': '默认媒体组不能删除',
+    'ja-JP': 'デフォルトメディアグループは削除できません',
   },
 
   // 12750 (assets)
   [ResponseCode.AssetNotFound]: {
     'en-US': 'Asset not found',
     'zh-CN': '资源未找到',
+    'ja-JP': 'アセットが見つかりません',
   },
   [ResponseCode.AssetUploadFailed]: {
     'en-US': 'Failed to upload asset',
     'zh-CN': '资源上传失败',
+    'ja-JP': 'アセットのアップロードに失敗しました',
   },
 
   // 12800 (material)
   [ResponseCode.MaterialNotFound]: {
     'en-US': 'Material not found',
     'zh-CN': '素材未找到',
+    'ja-JP': '素材が見つかりません',
   },
   [ResponseCode.MaterialGroupNotFound]: {
     'en-US': 'Material group not found',
     'zh-CN': '素材分组未找到',
+    'ja-JP': '素材グループが見つかりません',
   },
   [ResponseCode.MaterialGroupDefaultNotAllowed]: {
     'en-US': 'Default material group cannot be deleted',
     'zh-CN': '默认素材组不能删除',
+    'ja-JP': 'デフォルト素材グループは削除できません',
   },
   [ResponseCode.MaterialAdaptationNotFound]: {
     'en-US': 'Material adaptation not found',
     'zh-CN': '素材适配内容未找到',
+    'ja-JP': '素材適合内容が見つかりません',
   },
   [ResponseCode.MaterialAdaptationFailed]: {
     'en-US': 'Failed to adapt material',
     'zh-CN': '素材适配失败',
+    'ja-JP': '素材の適合に失敗しました',
   },
 
   // 15000 (channel/publish)
   [ResponseCode.PublishRecordNotFound]: {
     'en-US': 'publish record with flowId {{flowId}} not found.',
     'zh-CN': '发布记录未找到',
+    'ja-JP': '公開記録が見つかりません',
   },
   [ResponseCode.ChannelAuthorizationExpired]: {
     'en-US': 'Authorization expired',
     'zh-CN': '授权已过期',
+    'ja-JP': '認証の有効期限が切れています',
   },
   [ResponseCode.ChannelAccountInfoFailed]: {
     'en-US': 'Failed to get account information',
     'zh-CN': '账号信息获取失败',
+    'ja-JP': 'アカウント情報の取得に失敗しました',
   },
   [ResponseCode.PublishTaskNotFound]: {
     'en-US': 'Publish task not found',
     'zh-CN': '未发现任务',
+    'ja-JP': 'タスクが見つかりません',
   },
   [ResponseCode.ChannelWebhookFailed]: {
     'en-US': 'Webhook processing failed',
     'zh-CN': 'Webhook 处理失败',
+    'ja-JP': 'Webhook処理に失敗しました',
   },
   [ResponseCode.ChannelRefreshTokenFailed]: {
     'en-US': 'refresh Token failed for accountId: {{accountId}}',
     'zh-CN': '刷新令牌失败',
+    'ja-JP': 'トークンの更新に失敗しました',
   },
   [ResponseCode.ChannelAccessTokenFailed]: {
     'en-US': 'Failed to get access token',
     'zh-CN': '获取访问令牌失败',
+    'ja-JP': 'アクセストークンの取得に失敗しました',
   },
   [ResponseCode.ChannelPlatformTokenNotFound]: {
     'en-US': 'Platform authorization token not found',
     'zh-CN': '不存在平台授权令牌',
+    'ja-JP': 'プラットフォーム認証トークンが見つかりません',
   },
   [ResponseCode.ChannelAuthTaskFailed]: {
     'en-US': 'Failed to create authorization task',
     'zh-CN': '创建授权任务失败',
+    'ja-JP': '認証タスクの作成に失敗しました',
   },
   [ResponseCode.PublishTaskFailed]: {
     'en-US': 'task publish failed, accountType: {{accountType}}',
     'zh-CN': '任务发布失败',
+    'ja-JP': 'タスクの公開に失敗しました',
   },
   [ResponseCode.PublishTaskInProgress]: {
     'en-US': 'Task is in progress and cannot be deleted',
     'zh-CN': '任务正在执行中，无法删除',
+    'ja-JP': 'タスクが実行中のため削除できません',
   },
   [ResponseCode.PublishTaskStatusInvalid]: {
     'en-US': 'Task has been published or is in progress',
     'zh-CN': '任务已发布或正在进行中',
+    'ja-JP': 'タスクは公開済みまたは実行中です',
   },
   [ResponseCode.EngagementTaskInProgress]: {
     'en-US': 'Reply task for this post is already in progress',
     'zh-CN': '该帖子的回复任务已在进行中',
+    'ja-JP': 'この投稿の返信タスクは既に進行中です',
   },
   [ResponseCode.ChannelAccountNotFound]: {
     'en-US': 'Account not found',
     'zh-CN': '账户不存在',
+    'ja-JP': 'アカウントが見つかりません',
   },
   [ResponseCode.InteractAccountTypeNotSupported]: {
     'en-US': 'Account type not supported for interaction',
     'zh-CN': '暂不支持该账户类型',
+    'ja-JP': 'このアカウントタイプはサポートされていません',
   },
   [ResponseCode.InteractRecordNotFound]: {
     'en-US': 'Publish record not found',
     'zh-CN': '未找到发布记录',
+    'ja-JP': '公開記録が見つかりません',
   },
   [ResponseCode.DataCubeAccountTypeNotSupported]: {
     'en-US': 'Account type not supported for data cube',
     'zh-CN': '暂不支持该账户类型',
+    'ja-JP': 'このアカウントタイプはサポートされていません',
   },
   [ResponseCode.ChannelPublishTaskAlreadyExists]: {
     'en-US': 'publish task with flowId {{flowId}} already exists',
     'zh-CN': '发布任务已存在',
+    'ja-JP': '公開タスクは既に存在します',
   },
   [ResponseCode.PublishTaskNotPublished]: {
     'en-US': 'Publish task not published',
     'zh-CN': '发布任务未发布',
+    'ja-JP': '公開タスクは公開されていません',
   },
   [ResponseCode.PostCategoryNotSupported]: {
     'en-US': 'Post category not supported for update published post',
     'zh-CN': '暂不支持该帖子类型',
+    'ja-JP': 'この投稿タイプはサポートされていません',
   },
   [ResponseCode.PlatformNotSupported]: {
     'en-US': 'Platform not supported for update published post',
     'zh-CN': '暂不支持该平台',
+    'ja-JP': 'このプラットフォームはサポートされていません',
   },
   [ResponseCode.PublishTaskUpdateFailed]: {
     'en-US': 'Failed to update publish task',
     'zh-CN': '更新发布任务失败',
+    'ja-JP': '公開タスクの更新に失敗しました',
   },
   [ResponseCode.DeletePostFailed]: {
     'en-US': 'Failed to delete post',
     'zh-CN': '删除作品失败',
+    'ja-JP': '投稿の削除に失敗しました',
   },
   [ResponseCode.PublishTaskInvalid]: {
     'en-US': 'Publish task invalid',
     'zh-CN': '发布任务无效',
+    'ja-JP': '公開タスクが無効です',
   },
   [ResponseCode.InvalidWorkLink]: {
     'en-US': 'Invalid work link',
     'zh-CN': '作品链接无效',
+    'ja-JP': '作品リンクが無効です',
   },
   [ResponseCode.WorkNotBelongToAccount]: {
     'en-US': 'The work does not belong to this account',
     'zh-CN': '该作品不属于此账号',
+    'ja-JP': 'この作品はこのアカウントに属していません',
   },
 
   // 15100 (short-link)
   [ResponseCode.ShortLinkNotFound]: {
     'en-US': 'Short link not found',
     'zh-CN': '短链接不存在',
+    'ja-JP': '短縮リンクが見つかりません',
   },
 
   // 16000 (task)
   [ResponseCode.WorkDetailNotFound]: {
     'en-US': 'Work detail not found',
     'zh-CN': '无法获取作品详情',
+    'ja-JP': '作品の詳細を取得できません',
   },
   [ResponseCode.AccountAuthRequired]: {
     'en-US': 'This platform requires account authorization before submission',
     'zh-CN': '该平台需要先授权账号才能提交',
+    'ja-JP': 'このプラットフォームは送信前にアカウント認証が必要です',
   },
 
   // 16050 (task-material)
   [ResponseCode.MaterialGroupPlatformMismatch]: {
     'en-US': 'Material group platform does not match task platforms',
     'zh-CN': '草稿箱平台限制与任务平台不匹配',
+    'ja-JP': '下書きボックスのプラットフォーム制限がタスクプラットフォームと一致しません',
   },
 
   // 18100 (agent)
   [ResponseCode.AgentTaskNotFound]: {
     'en-US': 'Agent task not found',
     'zh-CN': '代理任务未找到',
+    'ja-JP': 'エージェントタスクが見つかりません',
   },
   [ResponseCode.AgentTaskStatusInvalid]: {
     'en-US': 'Agent task status is invalid',
     'zh-CN': '代理任务状态无效',
+    'ja-JP': 'エージェントタスクのステータスが無効です',
   },
   [ResponseCode.AgentTaskFailed]: {
     'en-US': 'Agent task failed',
     'zh-CN': '代理任务失败',
+    'ja-JP': 'エージェントタスクに失敗しました',
   },
   [ResponseCode.AgentTaskTimeout]: {
     'en-US': 'Agent task timeout: task has been running for too long without updates',
     'zh-CN': '代理任务超时：任务运行时间过长且未更新',
+    'ja-JP': 'エージェントタスクがタイムアウトしました：タスクが長時間実行されており更新がありません',
   },
   [ResponseCode.AgentTaskNotRunning]: {
     'en-US': 'Agent task is not running',
     'zh-CN': '代理任务未在运行状态',
+    'ja-JP': 'エージェントタスクは実行中ではありません',
   },
   [ResponseCode.AgentSessionRecoveryFailed]: {
     'en-US': 'Failed to recover agent session, please try to create a new conversation',
     'zh-CN': '恢复代理任务会话失败, 请尝试新建会话',
+    'ja-JP': 'エージェントセッションの復元に失敗しました。新しい会話を作成してください',
   },
 
   // 18400 (tools)
   [ResponseCode.QrCodeArtImageNotFound]: {
     'en-US': 'QR code art image not found',
     'zh-CN': '二维码艺术图未找到',
+    'ja-JP': 'QRコードアート画像が見つかりません',
   },
 
   // 19000 (api-key / relay)
   [ResponseCode.ApiKeyInvalid]: {
     'en-US': 'Invalid API key',
     'zh-CN': 'API Key 无效',
+    'ja-JP': 'API Keyが無効です',
   },
   [ResponseCode.RelayServerUnavailable]: {
     'en-US': 'Relay server unavailable',
     'zh-CN': '中转服务器不可用',
+    'ja-JP': 'リレーサーバーが利用できません',
   },
 }

--- a/project/aitoearn-backend/libs/common/src/i18n/notification-messages.ts
+++ b/project/aitoearn-backend/libs/common/src/i18n/notification-messages.ts
@@ -31,10 +31,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Task needs manual review',
       'zh-CN': '任务需要手动审核',
+      'ja-JP': 'タスクは手動レビューが必要です',
     },
     content: {
       'en-US': template.compile('AI review was skipped for task "{{taskTitle}}". Please review manually.'),
       'zh-CN': template.compile('任务"{{taskTitle}}"的 AI 审核已跳过，请手动审核。'),
+      'ja-JP': template.compile('タスク「{{taskTitle}}」のAIレビューがスキップされました。手動でレビューしてください。'),
     },
   },
 
@@ -42,10 +44,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'New task submission',
       'zh-CN': '新任务提交',
+      'ja-JP': '新しいタスクの提出',
     },
     content: {
       'en-US': template.compile('A user has submitted work for task "{{taskTitle}}". Please review.'),
       'zh-CN': template.compile('有用户提交了任务"{{taskTitle}}"的作品，请审核。'),
+      'ja-JP': template.compile('ユーザーがタスク「{{taskTitle}}」の作品を提出しました。レビューしてください。'),
     },
   },
 
@@ -53,10 +57,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Task review rejected',
       'zh-CN': '任务审核被拒绝',
+      'ja-JP': 'タスクレビューが拒否されました',
     },
     content: {
       'en-US': template.compile('Your submission for task "{{taskTitle}}" was rejected. {{rejectionReason}}'),
       'zh-CN': template.compile('您提交的任务"{{taskTitle}}"审核未通过。{{rejectionReason}}'),
+      'ja-JP': template.compile('タスク「{{taskTitle}}」の提出が拒否されました。{{rejectionReason}}'),
     },
   },
 
@@ -64,10 +70,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Task review approved',
       'zh-CN': '任务审核通过',
+      'ja-JP': 'タスクレビューが承認されました',
     },
     content: {
       'en-US': template.compile('Your submission for task "{{taskTitle}}" has been approved.'),
       'zh-CN': template.compile('您提交的任务"{{taskTitle}}"已审核通过。'),
+      'ja-JP': template.compile('タスク「{{taskTitle}}」の提出が承認されました。'),
     },
   },
 
@@ -75,10 +83,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Task settlement completed',
       'zh-CN': '任务结算完成',
+      'ja-JP': 'タスク決済完了',
     },
     content: {
       'en-US': template.compile('Your task "{{taskTitle}}" has been settled. Earnings have been credited to your balance.'),
       'zh-CN': template.compile('您的任务"{{taskTitle}}"已完成结算，收益已计入余额。'),
+      'ja-JP': template.compile('タスク「{{taskTitle}}」が決済されました。収益が残高に反映されました。'),
     },
   },
 
@@ -86,10 +96,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'You have a new task',
       'zh-CN': '您有新任务',
+      'ja-JP': '新しいタスクがあります',
     },
     content: {
       'en-US': 'You have a new task',
       'zh-CN': '您有新任务',
+      'ja-JP': '新しいタスクがあります',
     },
   },
 
@@ -97,10 +109,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Account binding required',
       'zh-CN': '需要绑定账号',
+      'ja-JP': 'アカウント連携が必要です',
     },
     content: {
       'en-US': 'Please authorize your account to complete task settlement',
       'zh-CN': '请授权您的账号以完成任务结算',
+      'ja-JP': 'タスク決済を完了するためにアカウントを認証してください',
     },
   },
 
@@ -108,10 +122,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Task reminder',
       'zh-CN': '任务提醒',
+      'ja-JP': 'タスクリマインダー',
     },
     content: {
       'en-US': 'Please login to complete the task',
       'zh-CN': '请登录以完成任务',
+      'ja-JP': 'タスクを完了するためにログインしてください',
     },
   },
 
@@ -119,10 +135,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Account Login Reminder',
       'zh-CN': '账号登录提醒',
+      'ja-JP': 'アカウントログインリマインダー',
     },
     content: {
       'en-US': template.compile('{{message}}'),
       'zh-CN': template.compile('{{message}}'),
+      'ja-JP': template.compile('{{message}}'),
     },
   },
 
@@ -130,10 +148,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Interaction task needs manual review',
       'zh-CN': '互动任务需要人工审核',
+      'ja-JP': 'インタラクションタスクは手動レビューが必要です',
     },
     content: {
       'en-US': template.compile('AI review failed for interaction task "{{taskTitle}}". Reason: {{reason}}. Please review manually.'),
       'zh-CN': template.compile('互动任务"{{taskTitle}}"的 AI 审核未通过，原因：{{reason}}，请手动复审。'),
+      'ja-JP': template.compile('インタラクションタスク「{{taskTitle}}」のAIレビューに失敗しました。理由：{{reason}}。手動でレビューしてください。'),
     },
   },
 
@@ -141,10 +161,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Punishment',
       'zh-CN': '处罚通知',
+      'ja-JP': 'ペナルティ通知',
     },
     content: {
       'en-US': template.compile('You have been punished for {{taskTitle}}'),
       'zh-CN': template.compile('您因"{{taskTitle}}"受到处罚'),
+      'ja-JP': template.compile('「{{taskTitle}}」によりペナルティを受けました'),
     },
   },
 
@@ -152,10 +174,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': template.compile('Agent Result {{status}}'),
       'zh-CN': template.compile('代理任务结果：{{status}}'),
+      'ja-JP': template.compile('エージェント結果：{{status}}'),
     },
     content: {
       'en-US': template.compile('Your Agent Task [{{taskId}}] is {{status}}'),
       'zh-CN': template.compile('您的代理任务 [{{taskId}}] 状态为{{status}}'),
+      'ja-JP': template.compile('エージェントタスク [{{taskId}}] のステータスは{{status}}です'),
     },
   },
 
@@ -163,10 +187,12 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Agent Result RequiresAction',
       'zh-CN': '代理任务需要操作',
+      'ja-JP': 'エージェントタスクにアクションが必要',
     },
     content: {
       'en-US': template.compile('Your Agent Task [{{taskId}}] requires action (e.g., connect a channel)'),
       'zh-CN': template.compile('您的代理任务 [{{taskId}}] 需要操作（例如：连接频道）'),
+      'ja-JP': template.compile('エージェントタスク [{{taskId}}] にアクションが必要です（例：チャンネル接続）'),
     },
   },
 
@@ -174,20 +200,24 @@ const notificationMessages: Record<NotificationMessageKey, NotificationMessageDe
     title: {
       'en-US': 'Forwarded Agent Task',
       'zh-CN': '转发的代理任务',
+      'ja-JP': '転送されたエージェントタスク',
     },
     content: {
       'en-US': template.compile('Task {{taskId}} has been forwarded to you.'),
       'zh-CN': template.compile('任务 {{taskId}} 已转发给您。'),
+      'ja-JP': template.compile('タスク {{taskId}} があなたに転送されました。'),
     },
   },
   [NotificationMessageKey.AppRelease]: {
     title: {
       'en-US': 'New version released',
       'zh-CN': '新版本发布',
+      'ja-JP': '新バージョンリリース',
     },
     content: {
       'en-US': template.compile('A new {{platform}} version {{version}} has been released.'),
       'zh-CN': template.compile('{{platform}} 新版本 {{version}} 已发布。'),
+      'ja-JP': template.compile('{{platform}}の新バージョン{{version}}がリリースされました。'),
     },
   },
 }
@@ -221,5 +251,6 @@ export function resolveNotificationMessageAllLocales(
   return {
     'en-US': resolveNotificationMessage(messageKey, 'en-US', vars),
     'zh-CN': resolveNotificationMessage(messageKey, 'zh-CN', vars),
+    'ja-JP': resolveNotificationMessage(messageKey, 'ja-JP', vars),
   }
 }

--- a/project/aitoearn-backend/libs/common/src/i18n/verify-code-messages.ts
+++ b/project/aitoearn-backend/libs/common/src/i18n/verify-code-messages.ts
@@ -4,10 +4,12 @@ const verifyCodeMessages: Record<string, Record<Locale, string>> = {
   DRAFT_SIMILARITY_LOW: {
     'en-US': 'The submitted work does not match the draft content. Please verify consistency.',
     'zh-CN': '提交的作品与草稿内容不一致，请注意核实。',
+    'ja-JP': '提出された作品が下書きの内容と一致しません。整合性を確認してください。',
   },
   WORK_PUBLISH_TIME_EXPIRED: {
     'en-US': 'The work publish time has exceeded the allowed limit (must be within 31 days).',
     'zh-CN': '作品发布时间超过限制（必须在 31 天内），请核实。',
+    'ja-JP': '作品の公開時間が制限を超えています（31日以内である必要があります）。確認してください。',
   },
 }
 

--- a/project/aitoearn-backend/libs/common/src/utils/i18n.util.ts
+++ b/project/aitoearn-backend/libs/common/src/utils/i18n.util.ts
@@ -4,6 +4,7 @@ import { getLocale } from '../interceptors/request-context.interceptor'
 const i18nObjectSchema = z.object({
   'en-US': z.string(),
   'zh-CN': z.string(),
+  'ja-JP': z.string().optional(),
 })
 
 export type I18nObject = z.infer<typeof i18nObjectSchema>

--- a/project/aitoearn-web/src/app/i18n/locales/ja/translation.json
+++ b/project/aitoearn-web/src/app/i18n/locales/ja/translation.json
@@ -1,4 +1,96 @@
 {
-  "title": "Aitoearn: 最高のオープンソースコンテンツAIエージェント",
-  "content": "最高のオープンソースマトリックスツール"
+  "title": "Aitoearn：個人ビジネス向けAIコンテンツマーケティングエージェント",
+  "content": "最高のオープンソースマトリックスツール",
+  "common": {
+    "loading": "読み込み中...",
+    "error": "エラーが発生しました",
+    "success": "成功しました",
+    "cancel": "キャンセル",
+    "confirm": "確認",
+    "save": "保存",
+    "delete": "削除",
+    "edit": "編集",
+    "create": "作成",
+    "search": "検索",
+    "submit": "送信",
+    "back": "戻る",
+    "next": "次へ",
+    "previous": "前へ",
+    "close": "閉じる",
+    "settings": "設定",
+    "logout": "ログアウト",
+    "login": "ログイン",
+    "register": "新規登録",
+    "profile": "プロフィール"
+  },
+  "nav": {
+    "home": "ホーム",
+    "accounts": "アカウント",
+    "publish": "公開",
+    "create": "作成",
+    "engage": "エンゲージメント",
+    "monetize": "収益化",
+    "settings": "設定",
+    "tasks": "タスク履歴"
+  },
+  "platforms": {
+    "douyin": "抖音（Douyin）",
+    "xhs": "小紅書（Rednote）",
+    "kuaishou": "快手（Kuaishou）",
+    "bilibili": "bilibili",
+    "tiktok": "TikTok",
+    "youtube": "YouTube",
+    "facebook": "Facebook",
+    "instagram": "Instagram",
+    "threads": "Threads",
+    "twitter": "Twitter（X）",
+    "pinterest": "Pinterest",
+    "linkedin": "LinkedIn"
+  },
+  "publish": {
+    "title": "コンテンツを公開",
+    "selectAccount": "アカウントを選択",
+    "selectPlatform": "プラットフォームを選択",
+    "schedule": "予約投稿",
+    "publishNow": "今すぐ公開",
+    "uploadMedia": "メディアをアップロード",
+    "addCaption": "キャプションを追加",
+    "addTags": "タグを追加",
+    "calendar": "カレンダー"
+  },
+  "create": {
+    "title": "コンテンツを作成",
+    "videoContent": "動画コンテンツ",
+    "imageContent": "画像コンテンツ",
+    "textContent": "テキストコンテンツ",
+    "aiGenerate": "AIで生成",
+    "batchGenerate": "一括生成",
+    "template": "テンプレート"
+  },
+  "engage": {
+    "title": "エンゲージメント",
+    "autoLike": "自動いいね",
+    "autoFollow": "自動フォロー",
+    "autoComment": "自動コメント",
+    "smartReply": "AIスマート返信",
+    "commentMining": "コメントマイニング",
+    "brandMonitoring": "ブランドモニタリング"
+  },
+  "monetize": {
+    "title": "収益化",
+    "cps": "CPS（売上ベース）",
+    "cpe": "CPE（エンゲージメントベース）",
+    "cpm": "CPM（再生数ベース）",
+    "tasks": "タスク一覧",
+    "earnings": "収益履歴"
+  },
+  "settings": {
+    "title": "設定",
+    "general": "一般",
+    "account": "アカウント",
+    "apiKey": "API Key",
+    "language": "言語",
+    "theme": "テーマ",
+    "notifications": "通知"
+  }
 }


### PR DESCRIPTION
## 概要 / Summary

日本語（ja-JP）対応を追加しました。

## 変更内容 / Changes

### 追加ファイル
- \README_JA.md\ - 日本語版README
- \project/aitoearn-web/src/app/i18n/locales/ja/translation.json\ - フロントエンドUI翻訳

### 変更ファイル
- \README.md\, \README_EN.md\ - 言語切り替えリンクに日本語を追加
- バックエンドi18nファイル - APIエラーメッセージ、通知メッセージに日本語追加

## 対応言語
これで以下の言語がサポートされます：
- 简体中文
- English
- **日本語 (ja-JP)** ← New!

## テスト
- ローカルでビルド確認済み
- 翻訳ファイルのJSON形式確認済み

---
Contributed by Nisss78 with 🐑