### PR TITLE
Security: Insecure plaintext HTTP used for authentication service base URL

### DIFF
--- a/project/aitoearn-electron/server/src/lib/platAuth/comment.ts
+++ b/project/aitoearn-electron/server/src/lib/platAuth/comment.ts
@@ -1,2 +1,2 @@
-export const BaseUrl = 'http://plat-auth.yikart.cn';
+export const BaseUrl = 'https://plat-auth.yikart.cn';
 // export const BaseUrl = 'http://127.0.0.1:3333';


### PR DESCRIPTION
## Problem

The platform auth base URL uses `http://` instead of `https://`. Authentication traffic over HTTP is vulnerable to interception and modification (MITM), potentially exposing tokens and credentials.

**Severity**: `high`
**File**: `project/aitoearn-electron/server/src/lib/platAuth/comment.ts`

## Solution

Use HTTPS endpoints only for auth-related communication. Enforce TLS in configuration and reject non-HTTPS base URLs at startup.

## Changes

- `project/aitoearn-electron/server/src/lib/platAuth/comment.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
