### PR TITLE
Security: Unrestricted CORS enabled globally

### DIFF
--- a/project/aitoearn-backend/apps/aitoearn-server/src/main.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/main.ts
@@ -5,7 +5,13 @@ import { config } from './config'
 
 startApplication(AppModule, config, {
   setupApp: (app) => {
-    app.enableCors()
+    const corsOrigins = process.env.CORS_ORIGINS?.split(',').map((origin) => origin.trim()).filter(Boolean) ?? []
+    app.enableCors({
+      origin: corsOrigins.length > 0 ? corsOrigins : false,
+      methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization'],
+      credentials: false,
+    })
 
     app.setViewEngine('ejs')
     app.setBaseViewsDir(join(__dirname, 'views'))


### PR DESCRIPTION
## Problem

The server enables CORS with default settings (`app.enableCors()`), which commonly permits broad cross-origin access unless explicitly restricted. This can increase risk of cross-origin abuse for authenticated APIs.

**Severity**: `medium`
**File**: `project/aitoearn-backend/apps/aitoearn-server/src/main.ts`

## Solution

Configure CORS with an explicit allowlist of trusted origins, methods, and headers; disable credentials where not required.

## Changes

- `project/aitoearn-backend/apps/aitoearn-server/src/main.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
