### PR TITLE
fix(mcp): replace z.string().datetime() with z.string() to fix invalid MCP JSON Schema (#503)

### DIFF
--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/publish-mcp.schema.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/publish-mcp.schema.ts
@@ -75,7 +75,7 @@ export type PublishTaskOption = z.infer<typeof PublishTaskOptionSchema>
 const basePublishingFields = {
   accountId: z.string().describe('account id'),
   userTaskId: z.string().optional().describe('user task id'),
-  publishTime: z.string().datetime().optional().describe('publish time'),
+  publishTime: z.string().optional().describe('publish time (ISO 8601 format, e.g. 2025-01-01T00:00:00Z)'),
 }
 
 // Default schema for platforms without specific options


### PR DESCRIPTION
## Problem
When both the CN and international AiToEarn MCP servers are added to an LLM
client (e.g. Hermes), all MCP tools break with:

  Invalid schema for function 'mcp_aitoearn_cn_listMyPublishedTasks':
  [{'type': 'string', 'format': 'date-time'}, {'type': 'string', 'format': 'date-time'}]
  is not of type 'object', 'boolean'

## Root Cause
`z.string().datetime()` in Zod emits `{ type: 'string', format: 'date-time' }`
in the generated JSON Schema. Certain LLM backends (Hermes, strict
function-calling mode) reject this because the optional union produces an
array schema structure that violates their MCP parameter schema expectations.

## Fix
Replaced `z.string().datetime()` with `z.string()` in `basePublishingFields`
inside `publish-mcp.schema.ts`. The `.describe()` text now documents the
expected ISO 8601 format so LLMs still know what value to pass.

**1 line changed, 1 file touched.**

## Verification
- `grep -rn "z\.string()\.datetime()" src/core/` → empty (no other MCP schemas affected)
- TypeScript: change is type-safe (z.string() is a superset, no call-site narrowing lost)
- node_modules not installed locally — please confirm `pnpm nx build aitoearn-server` passes on your end

Fixes #503