### PR TITLE
fix(twitter): resolve video publishing stuck in 'publishing' state

### DIFF
--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/twitter/twitter.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/twitter/twitter.service.ts
@@ -328,6 +328,7 @@ export class TwitterService {
         Authorization: `Bearer ${accessToken}`,
       },
       params: {
+        command: 'STATUS',
         media_id: mediaId,
       },
     }

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/publishing/providers/twitter.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/publishing/providers/twitter.service.ts
@@ -51,6 +51,20 @@ export class TwitterPubService extends PublishService {
 
   override async getMediaProcessingStatus(accountId: string, mediaId: string): Promise<string | void> {
     const mediaStatusInfo = await this.twitterService.getMediaUploadStatus(accountId, mediaId)
+    this.logger.debug({
+      path: '--- twitter getMediaProcessingStatus ---',
+      data: {
+        accountId,
+        mediaId,
+        mediaStatusInfo,
+      },
+    })
+    if (!mediaStatusInfo?.data?.processing_info) {
+      if (mediaStatusInfo?.data?.state === 'succeeded') {
+        return 'succeeded'
+      }
+      return 'in_progress'
+    }
     return mediaStatusInfo.data.processing_info.state
   }
 
@@ -420,11 +434,17 @@ export class TwitterPubService extends PublishService {
         errorMsg: `发布记录 ${publishRecord.id} 不包含有效的账号信息`,
       }
     }
+    if (!publishRecord.dataId) {
+      return {
+        success: false,
+        errorMsg: `发布记录 ${publishRecord.id} 不包含作品 ID，无法验证`,
+      }
+    }
     try {
       // Twitter/X 通过 API 获取推文信息验证发布状态
       const tweetInfo = await this.twitterService.getTweetDetail(
         publishRecord.accountId,
-        publishRecord.dataId || '',
+        publishRecord.dataId,
       )
 
       if (tweetInfo && tweetInfo.data && tweetInfo.data.id) {


### PR DESCRIPTION
This PR fixes a critical issue where Twitter video uploads remain stuck in the 'publishing' state indefinitely. 

### Changes:
1. **`libs/twitter/twitter.service.ts`**: Added the missing `command: 'STATUS'` parameter to the `getMediaStatus` API call, which is required by Twitter for polling processing status.
2. **`publishing/providers/twitter.service.ts`**: Improved status parsing to handle cases where `processing_info` might be missing but the upload has already succeeded. Added safety checks for `dataId` during verification.

These changes ensure the backend correctly identifies when a video has finished processing and proceeds to create the post.