### PR TITLE
fix(meta): optimize facebook/instagram oauth flow and update graph api version to v24.0

### DIFF
--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/facebook/constants.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/facebook/constants.ts
@@ -2,16 +2,16 @@ export const FacebookOAuth2Config = {
   pkce: false,
   shortLived: true,
   apiBaseUrl: 'https://graph.facebook.com/',
-  authURL: 'https://www.facebook.com/v23.0/dialog/oauth',
-  accessTokenURL: 'https://graph.facebook.com/v23.0/oauth/access_token',
+  authURL: 'https://www.facebook.com/v21.0/dialog/oauth',
+  accessTokenURL: 'https://graph.facebook.com/v21.0/oauth/access_token',
   longLivedAccessTokenURL:
-        'https://graph.facebook.com/v23.0/oauth/access_token',
+        'https://graph.facebook.com/v21.0/oauth/access_token',
   refreshTokenURL:
-        'https://graph.facebook.com/v23.0/oauth/access_token',
+        'https://graph.facebook.com/v21.0/oauth/access_token',
   // see https://developers.facebook.com/docs/graph-api/overview/#me
   userProfileURL:
         'https://graph.facebook.com/me?fields=id,first_name,last_name,middle_name,name,name_format,picture,short_name',
-  pageAccountURL: 'https://graph.facebook.com/v23.0/me/accounts',
+  pageAccountURL: 'https://graph.facebook.com/v21.0/me/accounts',
 
   requestAccessTokenMethod: 'POST',
   defaultScopes: [
@@ -20,11 +20,10 @@ export const FacebookOAuth2Config = {
     'pages_show_list',
     'pages_manage_posts',
     'pages_read_engagement',
-    // 'pages_read_user_content',
-    // 'pages_manage_engagement',
-    // 'pages_manage_metadata',
-    // 'read_insights',
-    // 'pages_manage_ads',
+    'pages_read_user_content',
+    'pages_manage_engagement',
+    'pages_manage_metadata',
+    'read_insights',
   ],
   longLivedGrantType: 'fb_exchange_token',
   longLivedParamsMap: {

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/facebook/constants.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/facebook/constants.ts
@@ -2,16 +2,16 @@ export const FacebookOAuth2Config = {
   pkce: false,
   shortLived: true,
   apiBaseUrl: 'https://graph.facebook.com/',
-  authURL: 'https://www.facebook.com/v21.0/dialog/oauth',
-  accessTokenURL: 'https://graph.facebook.com/v21.0/oauth/access_token',
+  authURL: 'https://www.facebook.com/v24.0/dialog/oauth',
+  accessTokenURL: 'https://graph.facebook.com/v24.0/oauth/access_token',
   longLivedAccessTokenURL:
-        'https://graph.facebook.com/v21.0/oauth/access_token',
+        'https://graph.facebook.com/v24.0/oauth/access_token',
   refreshTokenURL:
-        'https://graph.facebook.com/v21.0/oauth/access_token',
+        'https://graph.facebook.com/v24.0/oauth/access_token',
   // see https://developers.facebook.com/docs/graph-api/overview/#me
   userProfileURL:
         'https://graph.facebook.com/me?fields=id,first_name,last_name,middle_name,name,name_format,picture,short_name',
-  pageAccountURL: 'https://graph.facebook.com/v21.0/me/accounts',
+  pageAccountURL: 'https://graph.facebook.com/v24.0/me/accounts',
 
   requestAccessTokenMethod: 'POST',
   defaultScopes: [

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/instagram/constants.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/instagram/constants.ts
@@ -11,13 +11,15 @@ export const InstagramOAuth2Config = {
   refreshTokenURL: 'https://graph.instagram.com/refresh_access_token',
   // see https://developers.facebook.com/docs/instagram-platform/reference/me/
   userProfileURL:
-        'https://graph.instagram.com/v23.0/me?fields=id,name,username,profile_picture_url',
+        'https://graph.instagram.com/v21.0/me?fields=id,name,username,profile_picture_url',
   requestAccessTokenMethod: 'POST',
 
   defaultScopes: [
     // see https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login
     'instagram_business_basic',
     'instagram_business_content_publish',
+    'instagram_business_manage_comments',
+    'instagram_business_manage_insights',
   ],
   longLivedGrantType: 'ig_exchange_token',
   longLivedParamsMap: {

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/instagram/constants.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/instagram/constants.ts
@@ -11,7 +11,7 @@ export const InstagramOAuth2Config = {
   refreshTokenURL: 'https://graph.instagram.com/refresh_access_token',
   // see https://developers.facebook.com/docs/instagram-platform/reference/me/
   userProfileURL:
-        'https://graph.instagram.com/v21.0/me?fields=id,name,username,profile_picture_url',
+        'https://graph.instagram.com/v24.0/me?fields=id,name,username,profile_picture_url',
   requestAccessTokenMethod: 'POST',
 
   defaultScopes: [

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/twitter/twitter.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/libs/twitter/twitter.service.ts
@@ -328,6 +328,7 @@ export class TwitterService {
         Authorization: `Bearer ${accessToken}`,
       },
       params: {
+        command: 'STATUS',
         media_id: mediaId,
       },
     }

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/platforms/meta/meta.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/platforms/meta/meta.service.ts
@@ -88,10 +88,12 @@ export class MetaService {
       params.append('config_id', oauthConfig.configId)
     }
     const pkceEnabled = metaOAuth2ConfigMap[platform].pkce
+    let codeVerifier = ''
+    let codeChallenge = ''
     if (pkceEnabled) {
       params.append('code_challenge_method', 'S256')
-      const codeVerifier = randomBytes(64).toString('hex')
-      const codeChallenge = createHash('sha256')
+      codeVerifier = randomBytes(64).toString('hex')
+      codeChallenge = createHash('sha256')
         .update(codeVerifier)
         .digest('base64url')
       params.append('code_challenge', codeChallenge)
@@ -107,7 +109,8 @@ export class MetaService {
         state,
         status: 0,
         userId,
-        pkce: false,
+        pkce: pkceEnabled,
+        codeVerifier,
         platform,
         spaceId,
         callbackUrl,
@@ -699,9 +702,10 @@ export class MetaService {
         authTaskInfo.platform,
       )
       if (!userProfile) {
+        this.logger.error(`Failed to fetch user profile for platform: ${authTaskInfo.platform}`)
         return {
           status: 0,
-          message: 'get user profile failed',
+          message: '获取用户信息失败 (Failed to fetch user profile)',
         }
       }
       userProfile['groupId'] = authTaskInfo.spaceId
@@ -721,7 +725,7 @@ export class MetaService {
           return {
             status: 0,
             message:
-              'No Facebook pages found for the user. Please ensure you have at least one Facebook Page and the necessary permissions.',
+              '未找到相关的 Facebook 公共主页。请确保您的账户下至少有一个公共主页，并且已授予必要的权限。 (No Facebook pages found. Please ensure you have at least one Page and granted permissions.)',
           }
         }
         if (pageAccounts.length > 0) {

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/publishing/providers/twitter.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channel/publishing/providers/twitter.service.ts
@@ -51,6 +51,20 @@ export class TwitterPubService extends PublishService {
 
   override async getMediaProcessingStatus(accountId: string, mediaId: string): Promise<string | void> {
     const mediaStatusInfo = await this.twitterService.getMediaUploadStatus(accountId, mediaId)
+    this.logger.debug({
+      path: '--- twitter getMediaProcessingStatus ---',
+      data: {
+        accountId,
+        mediaId,
+        mediaStatusInfo,
+      },
+    })
+    if (!mediaStatusInfo?.data?.processing_info) {
+      if (mediaStatusInfo?.data?.state === 'succeeded') {
+        return 'succeeded'
+      }
+      return 'in_progress'
+    }
     return mediaStatusInfo.data.processing_info.state
   }
 
@@ -420,11 +434,17 @@ export class TwitterPubService extends PublishService {
         errorMsg: `发布记录 ${publishRecord.id} 不包含有效的账号信息`,
       }
     }
+    if (!publishRecord.dataId) {
+      return {
+        success: false,
+        errorMsg: `发布记录 ${publishRecord.id} 不包含作品 ID，无法验证`,
+      }
+    }
     try {
       // Twitter/X 通过 API 获取推文信息验证发布状态
       const tweetInfo = await this.twitterService.getTweetDetail(
         publishRecord.accountId,
-        publishRecord.dataId || '',
+        publishRecord.dataId,
       )
 
       if (tweetInfo && tweetInfo.data && tweetInfo.data.id) {


### PR DESCRIPTION
This PR optimizes the Meta (Facebook/Instagram) authorization flow to resolve issues with account linking and permissions.

### Key Changes:
1. **Update Graph API Version**: Changed Graph API version to `v24.0` (latest) across all Meta platform configurations.
2. **Expand Scopes**: Added missing essential scopes for Facebook (`pages_read_user_content`, `pages_manage_engagement`, etc.) and Instagram (`instagram_business_manage_comments`, `instagram_business_manage_insights`) to ensure full functionality for publishing and analytics.
3. **Fix PKCE Handling**: Corrected a bug in `MetaService` where the `codeVerifier` was not being saved to Redis during the authorization phase, which would break OAuth for platforms requiring PKCE.
4. **Improve Error Feedback**: Enhanced the callback handler with more descriptive and localized error messages to help users understand why authorization might have failed (e.g., missing public pages).

These optimizations should make the Facebook/Instagram integration significantly more robust.