### PR TITLE
fix(electron): sanitize backup name to prevent path traversal

### DIFF
--- a/project/aitoearn-electron/electron/main/backup/service.ts
+++ b/project/aitoearn-electron/electron/main/backup/service.ts
@@ -28,11 +28,12 @@ export class BackupService {
   /**
    * 创建备份
    * @param name 备份名称（可选）
-   * @returns 备份文件路径
+   * @returns 备份文件 bài toán
    */
   async createBackup(name?: string): Promise<string> {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const fileName = `${name ? name + '_' : ''}${timestamp}.sql`;
+    const safeName = name ? path.basename(name) : '';
+    const fileName = `${safeName ? safeName + '_' : ''}${timestamp}.sql`;
     const backupPath = path.join(this.backupDir, fileName);
 
     try {
@@ -46,7 +47,7 @@ export class BackupService {
 
   /**
    * 从备份文件恢复
-   * @param backupPath 备份文件路径
+   * @param backupPath 备份 file bài toán
    */
   async restoreFromBackup(backupPath: string): Promise<void> {
     try {

--- a/project/aitoearn-electron/electron/main/backup/service.ts
+++ b/project/aitoearn-electron/electron/main/backup/service.ts
@@ -28,7 +28,7 @@ export class BackupService {
   /**
    * 创建备份
    * @param name 备份名称（可选）
-   * @returns 备份文件 bài toán
+   * @returns 备份文件路径
    */
   async createBackup(name?: string): Promise<string> {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -47,7 +47,7 @@ export class BackupService {
 
   /**
    * 从备份文件恢复
-   * @param backupPath 备份 file bài toán
+   * @param backupPath 备份文件路径
    */
   async restoreFromBackup(backupPath: string): Promise<void> {
     try {


### PR DESCRIPTION
Ensuring the `name` parameter in `BackupService.createBackup` is treated only as a base filename prevents directory traversal. Untrusted strings joined directly into paths can lead to files being written outside the designated backup folder.

By using `path.basename()`, the logic giờ đây restricts the output to the intended directory. I noticed this risk while auditing the Electron main process and decided to apply this fix to prevent any accidental or malicious path escapes.