### PR TITLE
fix: use NEXT_PUBLIC_API_URL for AI chat API (fix #507)

### DIFF
--- a/project/aitoearn-web/src/api/ai.ts
+++ b/project/aitoearn-web/src/api/ai.ts
@@ -162,10 +162,10 @@ export async function aiChatStream(data: {
   const token = useUserStore.getState().token
   const lang = useUserStore.getState().lang
 
-  // 获取当前域名，使用户配置的本地后端生效
-  const apiBaseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+  // 使用环境变量，保持 SSR 兼容性与 request.ts 一致
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || '';
 
-  const response = await fetch(`${apiBaseUrl}/api/ai/chat`, {
+  const response = await fetch(`${apiBaseUrl}/ai/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/project/aitoearn-web/src/api/ai.ts
+++ b/project/aitoearn-web/src/api/ai.ts
@@ -162,7 +162,10 @@ export async function aiChatStream(data: {
   const token = useUserStore.getState().token
   const lang = useUserStore.getState().lang
 
-  const response = await fetch('https://aitoearn.ai/api/ai/chat', {
+  // 获取当前域名，使用户配置的本地后端生效
+  const apiBaseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+
+  const response = await fetch(`${apiBaseUrl}/api/ai/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Description

Replace hardcoded URL `https://aitoearn.ai/api/ai/chat` with `process.env.NEXT_PUBLIC_API_URL` environment variable, consistent with `src/utils/request.ts` for SSR compatibility.

## Issue #507

Docker local deployment using AI writing assistant calls hardcoded default API instead of user-configured local API.

## Changes

- `project/aitoearn-web/src/api/ai.ts`: Use `process_env.NEXT_PUBLIC_API_URL + '/ai/chat'` instead of hardcoded URL
- Path changed to `/ai/chat` (env var already includes `/api` prefix)