### PR TITLE
docs: add OpenClaw source workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://trendshift.io/repositories/20785" target="_blank"><img src="https://trendshift.io/api/badge/repositories/20785" alt="yikart%2FAiToEarn | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 [![GitHub stars](https://img.shields.io/github/stars/yikart/AiToEarn?color=fa6470)](https://github.com/yikart/AiToEarn/stargazers)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 [![Required Node.JS 20.18.x](https://img.shields.io/static/v1?label=node&message=20.18.x&logo=node.js&color=3f893e)](https://nodejs.org/about/releases)
 
 简体中文 | [English](README_EN.md) | [日本語](README_JA.md)
@@ -33,7 +33,7 @@ AiToEarn 通过 **AI Agent自动化**，帮助 OPC（一人公司）、创作者
 - **2026-04-20**: OpenClaw（龙虾）新增 AiToEarn 赚钱支持，可在龙虾中直接接收并执行内容变现任务。
 - **2026-03-26**: [2.1 version](https://www.aitoearn.ai/) — 内容交易市场上线；新增 OpenClaw（龙虾）支持，可在龙虾中直接使用 AiToEarn；新增 MCP 协议支持，可在 Claude、Cursor 等任何支持 MCP 的 Agent 或大模型中使用 AiToEarn。
 - **2026-02-07**: [1.8.0 version](https://www.aitoearn.ai/)，新增线下商户推广解决方案，支持餐厅、零售店、民宿、美容美发、健身房等多种线下业态，将线下推广活动转化为可执行的线上传播任务，通过内容发布与用户参与机制，帮助门店获取更多线上曝光和到店流量。
-- **2025-12-15**: "All In Agent" 的开始！我们加入了能够自动内容生成和发布以及一些帮助你操作 Aitoearn 的超级 AI 智能 Agent。[v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/v1.4.3)
+- **2025-12-15**: "All In Agent" 的开始！我们加入了能够自动内容生成和发布以及一些帮助你操作 Aitoearn 的超级 AI 智能 Agent。[v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/1.4.3)
 - **2025-11-28**: 支持应用内自动更新。在创作界面新增大量 AI 功能，例如：缩写、扩写、图片生成、视频生成、标签生成等，并支持 Nano Banana Pro。[v1.4.0](https://github.com/yikart/AiToEarn/releases/tag/v1.4.0)
 - **2025-11-12**: 首个开源且可完全使用的版本。[v1.3.2](https://github.com/yikart/AiToEarn/releases/tag/v1.3.2)
 - **2025-09-16**: 首个出海版本，新增支持 Facebook、Instagram、Threads、Twitter、YouTube、TikTok、Pinterest。[v1.0.18](https://github.com/yikart/AiToEarn/releases/tag/v1.0.18)
@@ -175,6 +175,16 @@ npx -y @aitoearn/openclaw-plugin-cli
 安装完成后，你就可以在 OpenClaw 中直接接收并执行 AiToEarn 的赚钱任务：
 
 <img src="presentation/openclaw-earn-demo.png" alt="在 OpenClaw 中执行 AiToEarn 赚钱任务" width="360">
+
+**可选 X/Twitter 素材工作流**
+
+当 AiToEarn 任务需要从实时 X/Twitter 语境出发时，可在同一个 OpenClaw 工作区安装 [TweetClaw](https://github.com/Xquik-dev/tweetclaw)：
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+先用 TweetClaw 搜索 tweets 和 replies、查询用户、导出粉丝上下文、监控 tweets，并记录来源 URL、作者 handle、时间戳和互动信号。只把人工复核后的摘要或 URL 交给 AiToEarn 做草稿生成与分发。post tweets、post tweet replies、direct messages、media upload 和 media download 保持为单独审批动作。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ npx -y @aitoearn/openclaw-plugin-cli
 openclaw plugins install @xquik/tweetclaw
 ```
 
-先用 TweetClaw 搜索 tweets 和 replies、查询用户、导出粉丝上下文、监控 tweets，并记录来源 URL、作者 handle、时间戳和互动信号。只把人工复核后的摘要或 URL 交给 AiToEarn 做草稿生成与分发。post tweets、post tweet replies、direct messages、media upload 和 media download 保持为单独审批动作。
+先用 TweetClaw 搜索 tweets 和 replies、查询用户、导出粉丝上下文、监控 tweets，并记录来源 URL、作者 handle、时间戳和互动信号。只把人工复核后的摘要或 URL 交给 AiToEarn 做草稿生成与分发。`post tweets`、`post tweet replies`、`direct messages`、`media upload` 和 `media download` 保持为单独审批动作。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -3,7 +3,7 @@
 <a href="https://trendshift.io/repositories/20785" target="_blank"><img src="https://trendshift.io/api/badge/repositories/20785" alt="yikart%2FAiToEarn | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 [![GitHub stars](https://img.shields.io/github/stars/yikart/AiToEarn?color=fa6470)](https://github.com/yikart/AiToEarn/stargazers)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 [![Required Node.JS 20.18.x](https://img.shields.io/static/v1?label=node&message=20.18.x&logo=node.js&color=3f893e)](https://nodejs.org/about/releases)
 
 English | [简体中文](README.md) | [日本語](README_JA.md)
@@ -33,7 +33,7 @@ Douyin, Xiaohongshu (Rednote), Kuaishou, Bilibili, WeChat Channels, WeChat Offic
 - **2026-04-20**: OpenClaw now supports AiToEarn earning workflows, so you can receive and execute monetization tasks directly inside OpenClaw.
 - **2026-03-26**: [2.1 version](https://www.aitoearn.ai/) — Content marketplace launched; added OpenClaw support for using AiToEarn directly within OpenClaw; added MCP protocol support for using AiToEarn in Claude, Cursor, and any MCP-compatible Agent or LLM.
 - **2026-02-07**: [1.8.0 version](https://www.aitoearn.ai/) — Added offline business promotion solutions for restaurants, retail stores, hotels, beauty salons, gyms, and more.
-- **2025-12-15**: "All In Agent" arrives! We've introduced a super AI agent that can automatically generate and publish content. [v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/v1.4.3)
+- **2025-12-15**: "All In Agent" arrives! We've introduced a super AI agent that can automatically generate and publish content. [v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/1.4.3)
 - **2025-11-28**: Support automatic updates within the application. Added AI functions: abbreviation, expansion, image creation, video creation, tag generation, etc. [v1.4.0](https://github.com/yikart/AiToEarn/releases/tag/v1.4.0)
 - **2025-11-12**: The first open-source, fully usable version. [v1.3.2](https://github.com/yikart/AiToEarn/releases/tag/v1.3.2)
 - **2025-09-16**: First international version, added support for Facebook, Instagram, Threads, Twitter, YouTube, TikTok, Pinterest. [v1.0.18](https://github.com/yikart/AiToEarn/releases/tag/v1.0.18)
@@ -169,6 +169,16 @@ On first run, select the environment and enter your API Key. Make sure they matc
 After setup, you can receive and execute AiToEarn earning tasks directly inside OpenClaw:
 
 <img src="presentation/openclaw-earn-demo.png" alt="Run AiToEarn earning tasks in OpenClaw" width="360">
+
+**Optional X/Twitter source workflow**
+
+When an AiToEarn task starts from live X/Twitter context, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) in the same OpenClaw workspace:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Use TweetClaw to search tweets, search tweet replies, look up users, export follower context, monitor tweets, and capture source URLs, handles, timestamps, and engagement signals. Feed only reviewed summaries or URLs into AiToEarn draft generation and distribution. Keep post tweets, post tweet replies, direct messages, media upload, and media download as separate approval-gated actions.
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -178,7 +178,7 @@ When an AiToEarn task starts from live X/Twitter context, install [TweetClaw](ht
 openclaw plugins install @xquik/tweetclaw
 ```
 
-Use TweetClaw to search tweets, search tweet replies, look up users, export follower context, monitor tweets, and capture source URLs, handles, timestamps, and engagement signals. Feed only reviewed summaries or URLs into AiToEarn draft generation and distribution. Keep post tweets, post tweet replies, direct messages, media upload, and media download as separate approval-gated actions.
+Use TweetClaw to search tweets, search tweet replies, look up users, export follower context, monitor tweets, and capture source URLs, handles, timestamps, and engagement signals. Feed only reviewed summaries or URLs into AiToEarn draft generation and distribution. Keep `post tweets`, `post tweet replies`, `direct messages`, `media upload`, and `media download` as separate approval-gated actions.
 
 ---
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 <a href="https://trendshift.io/repositories/20785" target="_blank"><img src="https://trendshift.io/api/badge/repositories/20785" alt="yikart%2FAiToEarn | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 [![GitHub stars](https://img.shields.io/github/stars/yikart/AiToEarn?color=fa6470)](https://github.com/yikart/AiToEarn/stargazers)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 [![Required Node.JS 20.18.x](https://img.shields.io/static/v1?label=node&message=20.18.x&logo=node.js&color=3f893e)](https://nodejs.org/about/releases)
 
 日本語 | [简体中文](README.md) | [English](README_EN.md)
@@ -33,7 +33,7 @@ AiToEarnは**AI自動化**を通じて、クリエイター、ブランド、企
 - **2026-04-20**: OpenClaw（ロブスター）で AiToEarn の収益化タスクに新対応し、OpenClaw 内で直接受け取り実行できるようになりました。
 - **2026-03-26**: [2.1バージョン](https://www.aitoearn.ai/) — コンテンツ取引マーケットプレイスをリリース。OpenClaw（ロブスター）対応を追加し、OpenClaw内で直接AiToEarnを使用可能に。MCPプロトコル対応を追加し、Claude、CursorなどMCP対応のエージェントやLLMでAiToEarnを使用可能に。
 - **2026-02-07**: [1.8.0バージョン](https://www.aitoearn.ai/) — オフライン店舗プロモーションソリューションを追加。レストラン、小売店、民宿、美容室、ジムなど多様なオフラインビジネスに対応。オフラインのプロモーション活動を実行可能なオンライン拡散タスクに変換し、コンテンツ公開とユーザー参加メカニズムを通じて店舗のオンライン露出と来店トラフィックの増加を支援。
-- **2025-12-15**: 「All In Agent」の始まり！コンテンツの自動生成・公開、そしてAitoearnの操作を支援するスーパーAIエージェントを追加。[v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/v1.4.3)
+- **2025-12-15**: 「All In Agent」の始まり！コンテンツの自動生成・公開、そしてAitoearnの操作を支援するスーパーAIエージェントを追加。[v1.4.3](https://github.com/yikart/AiToEarn/releases/tag/1.4.3)
 - **2025-11-28**: アプリ内自動更新に対応。作成画面に多くのAI機能を追加：要約、拡張、画像生成、動画生成、タグ生成など。Nano Banana Proにも対応。[v1.4.0](https://github.com/yikart/AiToEarn/releases/tag/v1.4.0)
 - **2025-11-12**: 初のオープンソースで完全に使用可能なバージョン。[v1.3.2](https://github.com/yikart/AiToEarn/releases/tag/v1.3.2)
 - **2025-09-16**: 初の海外展開バージョン、Facebook、Instagram、Threads、Twitter、YouTube、TikTok、Pinterestに対応。[v1.0.18](https://github.com/yikart/AiToEarn/releases/tag/v1.0.18)
@@ -174,6 +174,16 @@ npx -y @aitoearn/openclaw-plugin-cli
 設定後は、OpenClaw 内で AiToEarn の収益化タスクを直接受け取り実行できます。
 
 <img src="presentation/openclaw-earn-demo.png" alt="OpenClaw で AiToEarn の収益化タスクを実行" width="360">
+
+**任意の X/Twitter ソースワークフロー**
+
+AiToEarn タスクをリアルタイムの X/Twitter 文脈から始める場合は、同じ OpenClaw ワークスペースに [TweetClaw](https://github.com/Xquik-dev/tweetclaw) を追加できます:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw で tweets と replies の検索、ユーザー確認、フォロワー文脈のエクスポート、tweets のモニタリングを行い、source URL、handle、timestamp、engagement signal を記録します。レビュー済みの要約または URL だけを AiToEarn のドラフト生成と配信に渡してください。post tweets、post tweet replies、direct messages、media upload、media download は別途承認が必要な操作として扱います。
 
 ---
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -183,7 +183,7 @@ AiToEarn タスクをリアルタイムの X/Twitter 文脈から始める場合
 openclaw plugins install @xquik/tweetclaw
 ```
 
-TweetClaw で tweets と replies の検索、ユーザー確認、フォロワー文脈のエクスポート、tweets のモニタリングを行い、source URL、handle、timestamp、engagement signal を記録します。レビュー済みの要約または URL だけを AiToEarn のドラフト生成と配信に渡してください。post tweets、post tweet replies、direct messages、media upload、media download は別途承認が必要な操作として扱います。
+TweetClaw で tweets と replies の検索、ユーザー確認、フォロワー文脈のエクスポート、tweets のモニタリングを行い、source URL、handle、timestamp、engagement signal を記録します。レビュー済みの要約または URL だけを AiToEarn のドラフト生成と配信に渡してください。`post tweets`、`post tweet replies`、`direct messages`、`media upload`、`media download` は別途承認が必要な操作として扱います。
 
 ---
 


### PR DESCRIPTION
Closes #537

## Summary
- Add an optional TweetClaw source workflow to the OpenClaw section in Chinese, English, and Japanese READMEs.
- Show the `openclaw plugins install @xquik/tweetclaw` path for reviewed X/Twitter source collection before AiToEarn draft generation.
- Fix README license badge links to `LICENSE.txt`.
- Fix the stale `v1.4.3` release URL to the existing `1.4.3` tag.

## Validation
- `git diff --check`
- Added-line secret scan
- Added-line dash scan
- `npm view @xquik/tweetclaw version openclaw.install --json`
- Touched README link sweep: 31 external URLs checked, only the existing local `http://localhost:8080` setup URL is not fetchable; 36 local links checked with no failures.