### PR TITLE
fix(ai): preserve plugin scenes and sanitize OpenAI chat params

### DIFF
--- a/project/aitoearn-backend/apps/aitoearn-ai/src/config.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/config.ts
@@ -81,7 +81,7 @@ export const aiModelsConfigSchema = z.object({
     tags: z.array(i18nObjectSchema).default([]),
     mainTag: z.string().optional(),
     channel: z.enum(AiLogChannel),
-    scenes: z.string().array().optional(),
+    scenes: z.array(z.string()).default([]),
     inputModalities: z.array(z.enum(['text', 'image', 'video', 'audio'])),
     outputModalities: z.array(z.enum(['text', 'image', 'video', 'audio'])),
     pricing: chatPricingSchema,

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/openai/openai.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/openai/openai.service.ts
@@ -52,7 +52,26 @@ export class OpenaiService {
   }
 
   async createRawStream(options: OpenAI.Chat.ChatCompletionCreateParamsStreaming) {
-    return this.openAI.chat.completions.create(options)
+    const allowedKeys = new Set([
+      'model', 'messages', 'stream', 'temperature', 'top_p', 'n', 'stop',
+      'max_tokens', 'max_completion_tokens', 'presence_penalty', 'frequency_penalty',
+      'logit_bias', 'user', 'tools', 'tool_choice', 'parallel_tool_calls',
+      'response_format', 'seed', 'stream_options', 'reasoning_effort',
+      'metadata', 'store', 'service_tier', 'prediction', 'modalities', 'audio',
+    ])
+    const cleanOptions = Object.fromEntries(
+      Object.entries(options).filter(([key, value]) => allowedKeys.has(key) && value !== undefined),
+    )
+
+    const model = String(cleanOptions.model || '')
+    if (model === 'gpt-5' || model.startsWith('gpt-5-')) {
+      if (cleanOptions.max_tokens !== undefined && cleanOptions.max_completion_tokens === undefined) {
+        cleanOptions.max_completion_tokens = cleanOptions.max_tokens
+      }
+      delete cleanOptions.max_tokens
+    }
+
+    return this.openAI.chat.completions.create(cleanOptions)
   }
 
   async createChatCompletion(options: Partial<OpenAIChatInput> & {

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/openai/openai.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/openai/openai.service.ts
@@ -57,21 +57,23 @@ export class OpenaiService {
       'max_tokens', 'max_completion_tokens', 'presence_penalty', 'frequency_penalty',
       'logit_bias', 'user', 'tools', 'tool_choice', 'parallel_tool_calls',
       'response_format', 'seed', 'stream_options', 'reasoning_effort',
+      'logprobs', 'top_logprobs',
       'metadata', 'store', 'service_tier', 'prediction', 'modalities', 'audio',
     ])
     const cleanOptions = Object.fromEntries(
       Object.entries(options).filter(([key, value]) => allowedKeys.has(key) && value !== undefined),
-    )
+    ) as any
 
     const model = String(cleanOptions.model || '')
-    if (model === 'gpt-5' || model.startsWith('gpt-5-')) {
+    const isReasoningOrGpt5 = /^o\d/.test(model) || model === 'gpt-5' || model.startsWith('gpt-5-')
+    if (isReasoningOrGpt5) {
       if (cleanOptions.max_tokens !== undefined && cleanOptions.max_completion_tokens === undefined) {
         cleanOptions.max_completion_tokens = cleanOptions.max_tokens
       }
       delete cleanOptions.max_tokens
     }
 
-    return this.openAI.chat.completions.create(cleanOptions)
+    return this.openAI.chat.completions.create(cleanOptions as OpenAI.Chat.ChatCompletionCreateParamsStreaming)
   }
 
   async createChatCompletion(options: Partial<OpenAIChatInput> & {

--- a/project/aitoearn-backend/libs/aitoearn-ai-shared/src/vos/chat.vo.ts
+++ b/project/aitoearn-backend/libs/aitoearn-ai-shared/src/vos/chat.vo.ts
@@ -84,7 +84,7 @@ export const chatModelSchema = z.object({
   tags: z.array(zodI18nString()).default([]),
   mainTag: z.string().optional(),
   channel: z.enum(AiLogChannel).describe('渠道'),
-  scenes: z.string().array().optional().describe('适用场景'),
+  scenes: z.array(z.string()).default([]).describe('适用场景'),
   inputModalities: z.array(z.enum(['text', 'image', 'video', 'audio'])),
   outputModalities: z.array(z.enum(['text', 'image', 'video', 'audio'])),
   pricing: z.union([


### PR DESCRIPTION
## Summary

This PR fixes self-hosted plugin chat issues related to model scene metadata and OpenAI chat parameter forwarding.

Changes included:

- Preserve `scenes` as an array in AI model schemas.
- Ensure model responses expose `scenes` as `[]` instead of `undefined`.
- Sanitize OpenAI chat completion parameters before calling the OpenAI SDK.
- Prevent internal request fields from being forwarded to OpenAI-compatible APIs.
- Normalize `max_tokens` to `max_completion_tokens` for GPT-5 / `gpt-5-*` models.

## Problem

In self-hosted local plugin mode, plugin chat requests may include internal fields such as:

- `source`
- `billingGroupId`
- `userId`
- `userType`

These fields are application-level metadata and should not be forwarded to OpenAI chat completion APIs. Forwarding them can produce `400 Unknown parameter` errors.

Additionally, when model `scenes` is missing or `undefined`, plugin-side filtering such as:

```js
model.scenes.includes("plugin")
```

can fail or result in an empty plugin model list.

GPT-5-compatible models may also reject `max_tokens` and expect `max_completion_tokens` instead.

## Solution

This PR makes the OpenAI provider boundary stricter:

- Only known OpenAI chat completion parameters are forwarded.
- Internal application fields are dropped before the SDK call.
- GPT-5 / `gpt-5-*` requests convert `max_tokens` to `max_completion_tokens`.
- `scenes` defaults to an empty array in the model schemas.

## Scope

Changed files:

- `apps/aitoearn-ai/src/config.ts`
- `apps/aitoearn-ai/src/core/ai/libs/openai/openai.service.ts`
- `libs/aitoearn-ai-shared/src/vos/chat.vo.ts`

This PR does not add a new provider and does not modify deployment-specific files.

## Safety

This PR does not include:

- `.env`
- API keys
- local backups
- Docker patch scripts
- local deployment reports
- provider-specific additions outside OpenAI

## Local verification

Verified in a self-hosted local plugin deployment:

- Plugin model list returns plugin-capable GPT models.
- Plugin chat no longer forwards internal fields to OpenAI.
- No `source` / `billingGroupId` unknown-parameter errors after sanitization.
- GPT-5-compatible requests normalize `max_tokens` correctly.