### PR TITLE
[codex] Add MiniMax media provider

### DIFF
--- a/DOCKER_DEPLOYMENT_CN.md
+++ b/DOCKER_DEPLOYMENT_CN.md
@@ -425,6 +425,61 @@ GEMINI_KEY_PAIRS: '[{"projectId":"your-project","apiKey":"your-key","keyFile":"/
 
 </details>
 
+#### MiniMax
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `MINIMAX_API_KEY` | MiniMax API Key | |
+| `MINIMAX_BASE_URL` | MiniMax API 地址；可选，未配置时使用官方地址 | `https://api.minimax.io` |
+
+如果 `OPENAI_BASE_URL` 已指向 MiniMax 兼容地址（例如 `https://api.minimaxi.com/v1`），且未单独配置 `MINIMAX_API_KEY`，系统会复用 `OPENAI_API_KEY` 调用 MiniMax 文本与媒体能力。
+
+**内置模型：**
+
+| 模型 ID | 类型 | 说明 |
+|---------|------|------|
+| `MiniMax-M3` | 对话 | MiniMax M3，多模态对话模型 |
+| `minimax-image-01` | 图片生成 / 草稿生成 | 文生图，支持常见比例与自定义尺寸 |
+| `minimax-hailuo-2.3` | 视频生成 | text/image/首尾帧 → video，支持 768P/1080P |
+| `minimax-hailuo-2.3-fast` | 视频生成 | image → video，快速模式 |
+
+<details>
+<summary>模型配置示例</summary>
+
+```js
+// 图片模型 → ai.models.image.generation
+{
+  name: 'minimax-image-01',
+  description: 'MiniMax Image 01',
+  channel: 'minimax',
+  runtimeModel: 'image-01',
+  sizes: ['1024x1024', '1280x720', '720x1280'],
+  qualities: ['standard'],
+  styles: [],
+  pricing: '0.35',
+},
+
+// 视频模型 → ai.models.video.generation
+{
+  name: 'minimax-hailuo-2.3',
+  description: 'MiniMax Hailuo 2.3',
+  channel: 'minimax',
+  modes: ['text2video', 'image2video', 'flf2video'],
+  resolutions: ['768P', '1080P'],
+  durations: [6, 10],
+  maxInputImages: 2,
+  aspectRatios: ['1:1', '16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '21:9'],
+  defaults: { duration: 6, aspectRatio: '9:16', resolution: '768P' },
+  pricing: [
+    { resolution: '768P', duration: 6, price: 28 },
+    { resolution: '768P', duration: 10, price: 56 },
+    { resolution: '1080P', duration: 6, price: 49 },
+  ],
+},
+```
+
+</details>
+
 #### xAI (Grok)
 
 | 变量 | 说明 |

--- a/DOCKER_DEPLOYMENT_EN.md
+++ b/DOCKER_DEPLOYMENT_EN.md
@@ -425,6 +425,61 @@ GEMINI_KEY_PAIRS: '[{"projectId":"your-project","apiKey":"your-key","keyFile":"/
 
 </details>
 
+#### MiniMax
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MINIMAX_API_KEY` | MiniMax API key | |
+| `MINIMAX_BASE_URL` | MiniMax API URL; optional, falls back to the official endpoint | `https://api.minimax.io` |
+
+If `OPENAI_BASE_URL` already points to a MiniMax-compatible endpoint (for example `https://api.minimaxi.com/v1`) and `MINIMAX_API_KEY` is not set, the service reuses `OPENAI_API_KEY` for MiniMax text and media calls.
+
+**Built-in models:**
+
+| Model ID | Type | Description |
+|----------|------|-------------|
+| `MiniMax-M3` | Chat | MiniMax M3 multimodal chat model |
+| `minimax-image-01` | Image / Draft generation | Text-to-image with common aspect ratios and custom sizes |
+| `minimax-hailuo-2.3` | Video generation | text/image/first-last-frame → video, supports 768P/1080P |
+| `minimax-hailuo-2.3-fast` | Video generation | image → video, fast mode |
+
+<details>
+<summary>Model configuration example</summary>
+
+```js
+// Image model → ai.models.image.generation
+{
+  name: 'minimax-image-01',
+  description: 'MiniMax Image 01',
+  channel: 'minimax',
+  runtimeModel: 'image-01',
+  sizes: ['1024x1024', '1280x720', '720x1280'],
+  qualities: ['standard'],
+  styles: [],
+  pricing: '0.35',
+},
+
+// Video model → ai.models.video.generation
+{
+  name: 'minimax-hailuo-2.3',
+  description: 'MiniMax Hailuo 2.3',
+  channel: 'minimax',
+  modes: ['text2video', 'image2video', 'flf2video'],
+  resolutions: ['768P', '1080P'],
+  durations: [6, 10],
+  maxInputImages: 2,
+  aspectRatios: ['1:1', '16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '21:9'],
+  defaults: { duration: 6, aspectRatio: '9:16', resolution: '768P' },
+  pricing: [
+    { resolution: '768P', duration: 6, price: 28 },
+    { resolution: '768P', duration: 10, price: 56 },
+    { resolution: '1080P', duration: 6, price: 49 },
+  ],
+},
+```
+
+</details>
+
 #### xAI (Grok)
 
 | Variable | Description |

--- a/project/aitoearn-backend/apps/aitoearn-ai/config/config.js
+++ b/project/aitoearn-backend/apps/aitoearn-ai/config/config.js
@@ -36,6 +36,8 @@ const {
   GEMINI_BASE_URL,
   DASHSCOPE_API_KEY,
   DASHSCOPE_BASE_URL,
+  MINIMAX_API_KEY,
+  MINIMAX_BASE_URL,
 } = process.env
 
 const {
@@ -64,6 +66,80 @@ const GPT_IMAGE_2_SIZES = [
 ]
 
 const GPT_IMAGE_2_ASPECT_RATIOS = ['1:1', '3:2', '2:3', '4:3', '3:4', '5:4', '4:5', '16:9', '9:16']
+
+function normalizeBaseUrl(url) {
+  return url ? url.replace(/\/+$/, '') : url
+}
+
+function isMiniMaxBaseUrl(url) {
+  return /api\.minimax(?:i)?\.com$|api\.minimax\.io$/i.test(normalizeBaseUrl(url)?.replace(/\/v1$/, '') || '')
+}
+
+function resolveMiniMaxBaseUrl() {
+  if (MINIMAX_BASE_URL) {
+    return normalizeBaseUrl(MINIMAX_BASE_URL).replace(/\/v1$/, '')
+  }
+
+  if (isMiniMaxBaseUrl(OPENAI_BASE_URL)) {
+    return normalizeBaseUrl(OPENAI_BASE_URL).replace(/\/v1$/, '')
+  }
+
+  return 'https://api.minimax.io'
+}
+
+function resolveMiniMaxApiKey() {
+  if (MINIMAX_API_KEY) {
+    return MINIMAX_API_KEY
+  }
+
+  if (isMiniMaxBaseUrl(OPENAI_BASE_URL)) {
+    return OPENAI_API_KEY
+  }
+
+  return ''
+}
+
+function appendAnthropicMessagesEndpoint(url) {
+  const baseUrl = normalizeBaseUrl(url)
+
+  if (!baseUrl) {
+    return baseUrl
+  }
+
+  if (/\/v1\/messages$/i.test(baseUrl)) {
+    return baseUrl
+  }
+
+  if (/\/v1$/i.test(baseUrl)) {
+    return `${baseUrl}/messages`
+  }
+
+  return `${baseUrl}/v1/messages`
+}
+
+function resolveAnthropicCompatibleBaseUrl() {
+  if (isMiniMaxBaseUrl(OPENAI_BASE_URL)) {
+    return appendAnthropicMessagesEndpoint(`${normalizeBaseUrl(OPENAI_BASE_URL).replace(/\/v1$/, '')}/anthropic`)
+  }
+
+  if (ANTHROPIC_BASE_URL) {
+    return appendAnthropicMessagesEndpoint(ANTHROPIC_BASE_URL)
+  }
+
+  if (!OPENAI_BASE_URL) {
+    return OPENAI_BASE_URL
+  }
+
+  return `${normalizeBaseUrl(OPENAI_BASE_URL)}/messages`
+}
+
+function resolveAgentApiKey() {
+  if (isMiniMaxBaseUrl(OPENAI_BASE_URL)) {
+    return OPENAI_API_KEY
+  }
+
+  return ANTHROPIC_API_KEY || OPENAI_API_KEY
+}
 
 function parseGeminiKeyPairs() {
   if (!GEMINI_KEY_PAIRS) {
@@ -156,6 +232,10 @@ module.exports = {
     dashscope: {
       apiKey: DASHSCOPE_API_KEY || '',
       ...(DASHSCOPE_BASE_URL && { baseUrl: DASHSCOPE_BASE_URL }),
+    },
+    minimax: {
+      apiKey: resolveMiniMaxApiKey(),
+      baseUrl: resolveMiniMaxBaseUrl(),
     },
     aideo: {
       vCreative: {
@@ -293,33 +373,33 @@ module.exports = {
           },
         },
         {
-          name: 'gpt-5.4',
-          description: 'GPT 5.4',
+          name: 'MiniMax-M2.7',
+          description: 'MiniMax M2.7',
           channel: 'openai',
-          scenes: ['plugin', 'comment'],
-          inputModalities: ['text', 'image'],
+          scenes: ['web', 'plugin', 'comment'],
+          inputModalities: ['text'],
           outputModalities: ['text'],
           pricing: {
             tiers: [
               {
-                input: { text: '0.075' },
-                output: { text: '0.45' },
+                input: { text: '0' },
+                output: { text: '0' },
               },
             ],
           },
         },
         {
-          name: 'gpt-5.5',
-          description: 'GPT 5.5',
+          name: 'MiniMax-M3',
+          description: 'MiniMax M3',
           channel: 'openai',
           scenes: ['web', 'plugin', 'comment', 'draft-generation'],
-          inputModalities: ['text', 'image'],
+          inputModalities: ['text', 'image', 'video'],
           outputModalities: ['text'],
           pricing: {
             tiers: [
               {
-                input: { text: '0.075' },
-                output: { text: '0.45' },
+                input: { text: '0', image: '0', video: '0' },
+                output: { text: '0' },
               },
             ],
           },
@@ -362,6 +442,17 @@ module.exports = {
             styles: [],
             pricing: '1',
           },
+          {
+            name: 'minimax-image-01',
+            description: 'MiniMax Image 01',
+            channel: 'minimax',
+            runtimeModel: 'image-01',
+            tags: [],
+            sizes: ['1024x1024', '1280x720', '1152x864', '1248x832', '832x1248', '864x1152', '720x1280', '1344x576'],
+            qualities: ['standard'],
+            styles: [],
+            pricing: '0.35',
+          },
         ],
         edit: [
           {
@@ -389,6 +480,56 @@ module.exports = {
       },
       video: {
         generation: [
+          {
+            name: 'minimax-hailuo-2.3',
+            description: 'MiniMax Hailuo 2.3',
+            channel: 'minimax',
+            modes: ['text2video', 'image2video', 'flf2video'],
+            modeMappings: {
+              'text2video': 'MiniMax-Hailuo-2.3',
+              'image2video': 'MiniMax-Hailuo-2.3',
+              'flf2video': 'MiniMax-Hailuo-2.3',
+            },
+            resolutions: ['768P', '1080P'],
+            durations: [6, 10],
+            maxInputImages: 2,
+            aspectRatios: ['adaptive'],
+            tags: [],
+            defaults: {
+              resolution: '768P',
+              aspectRatio: 'adaptive',
+              duration: 6,
+            },
+            pricing: [
+              { resolution: '768P', duration: 6, price: 28 },
+              { resolution: '768P', duration: 10, price: 56 },
+              { resolution: '1080P', duration: 6, price: 49 },
+            ],
+          },
+          {
+            name: 'minimax-hailuo-2.3-fast',
+            description: 'MiniMax Hailuo 2.3 Fast',
+            channel: 'minimax',
+            modes: ['image2video'],
+            modeMappings: {
+              'image2video': 'MiniMax-Hailuo-2.3-Fast',
+            },
+            resolutions: ['768P', '1080P'],
+            durations: [6, 10],
+            maxInputImages: 1,
+            aspectRatios: ['adaptive'],
+            tags: [],
+            defaults: {
+              resolution: '768P',
+              aspectRatio: 'adaptive',
+              duration: 6,
+            },
+            pricing: [
+              { resolution: '768P', duration: 6, price: 19 },
+              { resolution: '768P', duration: 10, price: 32 },
+              { resolution: '1080P', duration: 6, price: 33 },
+            ],
+          },
           {
             name: 'happyhorse-1.0',
             description: 'HappyHorse 1.0',
@@ -578,7 +719,7 @@ module.exports = {
     },
     draftGeneration: {
       planner: {
-        defaultModel: 'gpt-5.5',
+        defaultModel: 'MiniMax-M3',
       },
       queue: {
         lowPriorityMinPriority: 1000,
@@ -609,12 +750,24 @@ module.exports = {
             { resolution: '1K', pricePerImage: 1, originPrice: 21.1 },
           ],
         },
+        {
+          model: 'minimax-image-01',
+          displayName: 'MiniMax Image 01',
+          runtimeModel: 'image-01',
+          queuePriority: 10,
+          tags: [],
+          supportedAspectRatios: ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'],
+          maxInputImages: 1,
+          pricing: [
+            { resolution: '1K', pricePerImage: 0.0035 },
+          ],
+        },
       ],
     },
   },
   agent: {
-    baseUrl: `${OPENAI_BASE_URL}/messages`,
-    apiKey: OPENAI_API_KEY,
+    baseUrl: resolveAnthropicCompatibleBaseUrl(),
+    apiKey: resolveAgentApiKey(),
     analysis: {
       model: 'gemini-3.1-pro-preview',
       apiKey: OPENAI_API_KEY,

--- a/project/aitoearn-backend/apps/aitoearn-ai/config/config.js
+++ b/project/aitoearn-backend/apps/aitoearn-ai/config/config.js
@@ -66,6 +66,7 @@ const GPT_IMAGE_2_SIZES = [
 ]
 
 const GPT_IMAGE_2_ASPECT_RATIOS = ['1:1', '3:2', '2:3', '4:3', '3:4', '5:4', '4:5', '16:9', '9:16']
+const GEMINI_IMAGE_BASE_URL = 'https://generativelanguage.googleapis.com'
 
 function normalizeBaseUrl(url) {
   return url ? url.replace(/\/+$/, '') : url
@@ -227,7 +228,7 @@ module.exports = {
       keyPairs: parseGeminiKeyPairs(),
       location: GEMINI_LOCATION || 'us-central1',
       apiKey: GEMINI_API_KEY,
-      baseUrl: GEMINI_BASE_URL,
+      baseUrl: GEMINI_BASE_URL || GEMINI_IMAGE_BASE_URL,
     },
     dashscope: {
       apiKey: DASHSCOPE_API_KEY || '',

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/config.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/config.ts
@@ -9,6 +9,7 @@ import z from 'zod'
 import { dashscopeConfigSchema } from './core/ai/libs/dashscope'
 import { geminiConfigSchema } from './core/ai/libs/gemini'
 import { grokConfigSchema } from './core/ai/libs/grok'
+import { minimaxConfigSchema } from './core/ai/libs/minimax'
 import { openaiConfigSchema } from './core/ai/libs/openai'
 import { volcengineConfigSchema } from './core/ai/libs/volcengine'
 
@@ -98,6 +99,7 @@ export const aiModelsConfigSchema = z.object({
       logo: z.string().optional(),
       tags: z.array(i18nObjectSchema).default([]),
       mainTag: z.string().optional(),
+      channel: z.enum(AiLogChannel).optional(),
       runtimeModel: z.string().optional(),
       sizes: z.array(z.string()),
       qualities: z.array(z.string()),
@@ -187,6 +189,7 @@ export const aiConfigSchema = z.object({
   }),
   grok: grokConfigSchema,
   dashscope: dashscopeConfigSchema,
+  minimax: minimaxConfigSchema,
   aideo: aideoPricingConfigSchema,
   gemini: geminiConfigSchema,
   anthropic: z.object({

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/mcp/media.mcp.spec.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/mcp/media.mcp.spec.ts
@@ -35,6 +35,7 @@ describe('mediaMcp', () => {
 
     mockImageService = {
       userGeminiGeneration: vi.fn(),
+      userGeneration: vi.fn(),
     } as unknown as vi.Mocked<ImageService>
 
     mockAiAvailability = {
@@ -65,7 +66,7 @@ describe('mediaMcp', () => {
       expect(tool.name).toBe(MediaToolName.GenerateImage)
     })
 
-    it('should call imageService.userGeminiGeneration with correct params', async () => {
+    it('should call imageService.userGeminiGeneration with correct params for reference images', async () => {
       mockImageService.userGeminiGeneration.mockResolvedValue({
         usage: { input_tokens: 100, output_tokens: 200, total_tokens: 300, points: 10 },
         images: [{ url: 'https://example.com/image1.png', data: '', mimeType: 'image/png' }],
@@ -86,6 +87,7 @@ describe('mediaMcp', () => {
         imageUrls: ['https://example.com/ref.png'],
         imageSize: '2K',
         aspectRatio: '16:9',
+        model: 'gemini-3.1-flash-image-preview',
       })
     })
 
@@ -109,13 +111,12 @@ describe('mediaMcp', () => {
     })
 
     it('should return generated image URLs', async () => {
-      mockImageService.userGeminiGeneration.mockResolvedValue({
-        usage: { input_tokens: 100, output_tokens: 200, total_tokens: 300, points: 10 },
-        images: [
-          { url: 'image1.png', data: '', mimeType: 'image/png' },
-          { url: 'image2.png', data: '', mimeType: 'image/png' },
+      mockImageService.userGeneration.mockResolvedValue({
+        list: [
+          { url: 'image1.png' },
+          { url: 'image2.png' },
         ],
-      })
+      } as never)
 
       const tool = mediaMcp.createGenerateImageTool(userId, userType)
       const result = await tool.handler({
@@ -134,11 +135,10 @@ describe('mediaMcp', () => {
       expect(resourceLinks.length).toBe(2)
     })
 
-    it('should use default empty array for imageUrls when not provided', async () => {
-      mockImageService.userGeminiGeneration.mockResolvedValue({
-        usage: { input_tokens: 100, output_tokens: 200, total_tokens: 300, points: 10 },
-        images: [{ url: 'image.png', data: '', mimeType: 'image/png' }],
-      })
+    it('should default text-to-image requests to MiniMax when imageUrls are not provided', async () => {
+      mockImageService.userGeneration.mockResolvedValue({
+        list: [{ url: 'image.png' }],
+      } as never)
 
       const tool = mediaMcp.createGenerateImageTool(userId, userType)
       await tool.handler({
@@ -148,9 +148,33 @@ describe('mediaMcp', () => {
         aspectRatio: undefined,
       } as never, {})
 
-      expect(mockImageService.userGeminiGeneration).toHaveBeenCalledWith(
+      expect(mockImageService.userGeneration).toHaveBeenCalledWith(
         expect.objectContaining({
-          imageUrls: [],
+          model: 'minimax-image-01',
+          n: 1,
+          size: '1024x1024',
+          response_format: 'url',
+        }),
+      )
+    })
+
+    it('should pass selected MiniMax model with an aspect-ratio size mapping', async () => {
+      mockImageService.userGeneration.mockResolvedValue({
+        list: [{ url: 'image.png' }],
+      } as never)
+
+      const tool = mediaMcp.createGenerateImageTool(userId, userType)
+      await tool.handler({
+        prompt: 'A poster',
+        model: 'minimax-image-01',
+        aspectRatio: '3:4',
+        imageSize: '2K',
+      } as never, {})
+
+      expect(mockImageService.userGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'minimax-image-01',
+          size: '864x1152',
         }),
       )
     })

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/mcp/media.mcp.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/mcp/media.mcp.ts
@@ -1,5 +1,5 @@
 import { createSdkMcpServer, McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk'
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { FileUtil, UserType } from '@yikart/common'
 import { AiLogStatus } from '@yikart/mongodb'
 import dayjs from 'dayjs'
@@ -15,8 +15,42 @@ const generateMediaSchema = z.object({
   imageUrls: z.array(z.string()).optional(),
   imageSize: z.enum(['1K', '2K', '4K']).optional(),
   aspectRatio: z.enum(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9']).optional(),
-  model: z.enum(['gemini-3.1-flash-image-preview', 'gemini-3-pro-image-preview']).optional(),
+  model: z.enum(['minimax-image-01', 'gemini-3.1-flash-image-preview', 'gemini-3-pro-image-preview']).optional(),
 })
+
+const MINIMAX_IMAGE_MODEL = 'minimax-image-01'
+const DEFAULT_GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview'
+const GEMINI_IMAGE_MODELS = [DEFAULT_GEMINI_IMAGE_MODEL, 'gemini-3-pro-image-preview'] as const
+type GeminiImageModel = typeof GEMINI_IMAGE_MODELS[number]
+
+function isGeminiImageModel(model: string): model is GeminiImageModel {
+  return (GEMINI_IMAGE_MODELS as readonly string[]).includes(model)
+}
+
+function resolveMiniMaxToolSize(aspectRatio?: string, imageSize?: string): string {
+  const sizeByAspectRatio: Record<string, string> = {
+    '1:1': '1024x1024',
+    '16:9': '1280x720',
+    '9:16': '720x1280',
+    '4:3': '1152x864',
+    '3:4': '864x1152',
+    '3:2': '1248x832',
+    '2:3': '832x1248',
+    '4:5': '1024x1280',
+    '5:4': '1280x1024',
+    '21:9': '1344x576',
+  }
+
+  if (aspectRatio && sizeByAspectRatio[aspectRatio]) {
+    return sizeByAspectRatio[aspectRatio]
+  }
+
+  if (imageSize === '2K' || imageSize === '4K') {
+    return '1280x720'
+  }
+
+  return '1024x1024'
+}
 
 const generateVideoSchema = z.object({
   prompt: z.string(),
@@ -90,14 +124,14 @@ export class MediaMcp {
     return wrapTool(
       this.logger,
       MediaToolName.GenerateImage,
-      `Generate an image using Gemini model.
+      `Generate an image using MiniMax or Gemini image models.
 
 Parameters:
 - prompt: Text description of the image
 - imageUrls (optional): Reference image URLs for editing
 - imageSize (optional): "1K", "2K", or "4K"
 - aspectRatio (optional): "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"
-- model (optional): "gemini-3.1-flash-image-preview" (default) or "gemini-3-pro-image-preview"
+- model (optional): "minimax-image-01" (default for text-to-image), "gemini-3.1-flash-image-preview" (default when imageUrls are provided), or "gemini-3-pro-image-preview"
 
 Returns the generated image URL(s).`,
       generateMediaSchema.shape,
@@ -105,17 +139,41 @@ Returns the generated image URL(s).`,
         this.logger.debug(`[generateImage] Starting image generation for user ${userId}`)
         const startTime = Date.now()
 
-        const result = await this.imageService.userGeminiGeneration({
-          userId,
-          userType,
-          prompt,
-          imageUrls,
-          imageSize,
-          aspectRatio,
-          ...(model ? { model } : {}),
-        })
+        const selectedModel = model ?? (imageUrls.length > 0 ? DEFAULT_GEMINI_IMAGE_MODEL : MINIMAX_IMAGE_MODEL)
+        let generatedImages: Array<{ url: string }>
 
-        const generatedImages = result.images.map(img => ({ ...img, url: FileUtil.buildUrl(img.url!) }))
+        if (selectedModel === MINIMAX_IMAGE_MODEL) {
+          if (imageUrls.length > 0) {
+            throw new BadRequestException('MiniMax image generation does not support imageUrls; use a Gemini image model for reference images')
+          }
+
+          const result = await this.imageService.userGeneration({
+            userId,
+            userType,
+            prompt,
+            model: selectedModel,
+            n: 1,
+            size: resolveMiniMaxToolSize(aspectRatio, imageSize),
+            response_format: 'url',
+          })
+          const images = result.list ?? result.data ?? []
+          generatedImages = images.map(img => ({ ...img, url: FileUtil.buildUrl(img.url!) }))
+        }
+        else if (isGeminiImageModel(selectedModel)) {
+          const result = await this.imageService.userGeminiGeneration({
+            userId,
+            userType,
+            prompt,
+            imageUrls,
+            imageSize,
+            aspectRatio,
+            model: selectedModel,
+          })
+          generatedImages = result.images.map(img => ({ ...img, url: FileUtil.buildUrl(img.url!) }))
+        }
+        else {
+          throw new BadRequestException(`Unsupported image model: ${selectedModel}`)
+        }
 
         const duration = Date.now() - startTime
         this.logger.debug(`[generateImage] Image generation completed in ${duration}ms for user ${userId}, count: ${generatedImages.length}`)

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/services/agent-runtime.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/services/agent-runtime.service.ts
@@ -60,7 +60,7 @@ import {
   ContentGenerationTaskResultUnionSchema,
 } from '../agent.vo'
 import { ImageEditMcp, ImageEditToolName } from '../mcp/image-edit.mcp'
-import { successResult, wrapTool } from '../mcp/mcp.utils'
+import { createHttpBridgeServer, successResult, wrapTool } from '../mcp/mcp.utils'
 import { MediaMcp, MediaToolName } from '../mcp/media.mcp'
 import { SubtitleMcp, SubtitleToolName } from '../mcp/subtitle.mcp'
 import { UtilMcp, UtilToolName } from '../mcp/util.mcp'
@@ -82,6 +82,41 @@ export interface ClaudeQueryOptions {
 }
 
 type TaskResult = z.infer<typeof ContentGenerationTaskResultUnionSchema>
+
+const ACCOUNT_MCP_TOOL_NAMES = [
+  'getAccountGroupList',
+  'getAccountListByGroupId',
+  'getAllAccounts',
+  'getAccountDetail',
+]
+
+const CONTENT_MCP_TOOL_NAMES = [
+  'getMediaGroupInfoByName',
+  'createMedia',
+  'getDraftGroupInfoByName',
+  'createDraft',
+  'listDrafts',
+  'getDraftDetail',
+  'deleteDraft',
+  'listMedia',
+  'listDraftGroups',
+  'listMediaGroups',
+]
+
+const PUBLISH_MCP_TOOL_NAMES = [
+  'getPublishingTaskStatus',
+  'publishRestrictions',
+  'publishPostToBilibili',
+  'publishPostToWxGzh',
+  'publishPostToYoutube',
+  'publishPostToPinterest',
+  'publishPostToThreads',
+  'publishPostToTiktok',
+  'publishPostToFacebook',
+  'publishPostToInstagram',
+  'publishPostToKwai',
+  'publishPostToTwitter',
+]
 
 export interface RuntimeRunningTaskInfo {
   taskId: string
@@ -184,6 +219,15 @@ export class AgentRuntimeService {
           break
         case McpServerName.Subtitle:
           toolNames = Object.values(SubtitleToolName)
+          break
+        case McpServerName.Account:
+          toolNames = ACCOUNT_MCP_TOOL_NAMES
+          break
+        case McpServerName.Content:
+          toolNames = CONTENT_MCP_TOOL_NAMES
+          break
+        case McpServerName.Publish:
+          toolNames = PUBLISH_MCP_TOOL_NAMES
           break
         default:
           continue
@@ -737,6 +781,22 @@ export class AgentRuntimeService {
 
     const headers = filterHeaders(req.headers)
     this.logger.debug({ headers }, 'mcp headers')
+    const unifiedMcpUrl = `${config.serverClient.baseUrl}/unified/mcp`
+    const accountMcp = await createHttpBridgeServer(
+      McpServerName.Account,
+      unifiedMcpUrl,
+      headers,
+    )
+    const contentMcp = await createHttpBridgeServer(
+      McpServerName.Content,
+      unifiedMcpUrl,
+      headers,
+    )
+    const publishMcp = await createHttpBridgeServer(
+      McpServerName.Publish,
+      unifiedMcpUrl,
+      headers,
+    )
     const mcpServers: Record<string, McpServerConfig> = {
       [McpServerName.MediaGeneration]: this.mediaMcp.createServer(userId, userType),
       [McpServerName.Util]: this.utilMcp.server,
@@ -747,21 +807,9 @@ export class AgentRuntimeService {
       [McpServerName.StyleTransfer]: this.styleTransferMcp.createServer(userId, userType),
       [McpServerName.ImageEdit]: this.imageEditMcp.createServer(userId, userType),
       // [McpServerName.Subtitle]: this.subtitleMcp.createServer(userId, userType),
-      [McpServerName.Account]: {
-        type: 'http',
-        url: `${config.serverClient.baseUrl}/account/mcp`,
-        headers,
-      },
-      [McpServerName.Content]: {
-        type: 'http',
-        url: `${config.serverClient.baseUrl}/content/mcp`,
-        headers,
-      },
-      [McpServerName.Publish]: {
-        type: 'http',
-        url: `${config.serverClient.baseUrl}/publish/mcp`,
-        headers,
-      },
+      [McpServerName.Account]: accountMcp,
+      [McpServerName.Content]: contentMcp,
+      [McpServerName.Publish]: publishMcp,
     }
 
     return {

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/skills/generating-images/SKILL.md
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/agent/skills/generating-images/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: generating-images
-description: Generates images using AI models (Gemini). AI图像生成、文生图、生成图片。
+description: Generates images using AI models (MiniMax or Gemini). AI图像生成、文生图、生成图片。
 ---
 
 # Image Generation
 
-Generates images using Gemini AI model (default: gemini-3.1-flash-image-preview, compatible: gemini-3-pro-image-preview).
+Generates images using MiniMax or Gemini AI models.
+
+- Default for text-to-image: `minimax-image-01`
+- Default for reference-image/editing workflows: `gemini-3.1-flash-image-preview`
+- Compatible Gemini model: `gemini-3-pro-image-preview`
 
 ## Parameters
 
@@ -18,6 +22,9 @@ Generates images using Gemini AI model (default: gemini-3.1-flash-image-preview,
 - `imageUrls`: Reference image URLs for editing
 - `imageSize`: Output resolution - "1K", "2K", "4K"
 - `aspectRatio`: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"
+- `model`: "minimax-image-01", "gemini-3.1-flash-image-preview", or "gemini-3-pro-image-preview"
+
+Use `minimax-image-01` for normal text-to-image requests. Use a Gemini image model when `imageUrls` are provided because reference images are handled through the Gemini image workflow.
 
 ## Workflow
 
@@ -91,6 +98,7 @@ Text in generated images MUST match user's language.
 ```
 generateImage:
   prompt: "A photorealistic close-up portrait of an elderly Japanese ceramicist with deep, sun-etched wrinkles and a warm, knowing smile. He is carefully inspecting a freshly glazed tea bowl."
+  model: "minimax-image-01"
   aspectRatio: "3:4"
   imageSize: "2K"
 ```
@@ -100,6 +108,7 @@ generateImage:
 ```
 generateImage:
   prompt: "A kawaii-style sticker of a happy red panda wearing a tiny bamboo hat. It's munching on a green bamboo leaf. The design features bold, clean outlines, simple cel-shading, and a vibrant color palette."
+  model: "minimax-image-01"
   aspectRatio: "1:1"
   imageSize: "1K"
 ```
@@ -109,6 +118,7 @@ generateImage:
 ```
 generateImage:
   prompt: "A high-resolution, studio-lit product photograph of a minimalist ceramic coffee mug in matte black, presented on a polished concrete surface."
+  model: "minimax-image-01"
   aspectRatio: "1:1"
   imageSize: "2K"
 ```
@@ -118,6 +128,7 @@ generateImage:
 ```
 generateImage:
   prompt: "A minimalist composition featuring a single, delicate red maple leaf positioned in the bottom-right of the frame. The background is a vast, empty off-white canvas."
+  model: "minimax-image-01"
   aspectRatio: "16:9"
   imageSize: "2K"
 ```
@@ -127,5 +138,6 @@ generateImage:
 ```
 generateImage:
   prompt: "Add a vibrant rainbow to the sky, keep all other elements unchanged"
+  model: "gemini-3.1-flash-image-preview"
   imageUrls: ["source.jpg"]
 ```

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/ai.module.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/ai.module.ts
@@ -4,6 +4,7 @@ import { AideoModule } from './aideo'
 import { AssetsModule } from './assets'
 import { ChatModule } from './chat'
 import { ImageModule } from './image'
+import { MiniMaxModule } from './libs/minimax'
 import { OpenaiModule } from './libs/openai'
 import { LogsModule } from './logs'
 import { ModelsConfigModule } from './models-config'
@@ -12,6 +13,7 @@ import { VideoModule } from './video'
 @Module({
   imports: [
     OpenaiModule.forRoot(config.ai.openai),
+    MiniMaxModule.forRoot(config.ai.minimax),
     ChatModule,
     LogsModule,
     ImageModule,

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/image/image.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/image/image.service.ts
@@ -11,6 +11,7 @@ import QRCode from 'qrcode'
 import sharp from 'sharp'
 
 import { GeminiService } from '../libs/gemini/gemini.service'
+import { MiniMaxService } from '../libs/minimax'
 import { OpenaiService } from '../libs/openai'
 import { ModelsConfigService } from '../models-config'
 import { calculatePricingPoints, ChatPricing } from '../pricing/pricing-calculator'
@@ -29,6 +30,7 @@ import {
 } from './image.dto'
 
 type Uploadable = File | Response
+type ImageGenerationModelConfig = ModelsConfigService['config']['image']['generation'][number]
 
 @Injectable()
 export class ImageService {
@@ -38,6 +40,7 @@ export class ImageService {
     private readonly assetsService: AssetsService,
     private readonly openaiService: OpenaiService,
     private readonly geminiService: GeminiService,
+    private readonly minimaxService: MiniMaxService,
     private readonly aiLogRepo: AiLogRepository,
     private readonly creditsHelper: CreditsHelperService,
     private readonly modelsConfigService: ModelsConfigService,
@@ -46,12 +49,20 @@ export class ImageService {
     private readonly asyncSettlementService: AsyncSettlementService,
   ) { }
 
-  private resolveRuntimeImageModel(model: string, kind: 'generation' | 'edit'): string {
-    const modelConfig = kind === 'generation'
+  private getImageModelConfig(model: string, kind: 'generation' | 'edit') {
+    return kind === 'generation'
       ? this.modelsConfigService.config.image.generation.find(item => item.name === model)
       : this.modelsConfigService.config.image.edit.find(item => item.name === model)
+  }
 
+  private resolveRuntimeImageModel(model: string, kind: 'generation' | 'edit'): string {
+    const modelConfig = this.getImageModelConfig(model, kind)
     return modelConfig?.runtimeModel ?? model
+  }
+
+  private resolveImageModelChannel(model: string, kind: 'generation' | 'edit'): AiLogChannel {
+    const modelConfig = this.getImageModelConfig(model, kind)
+    return (modelConfig as { channel?: AiLogChannel } | undefined)?.channel ?? AiLogChannel.NewApi
   }
 
   /**
@@ -109,12 +120,105 @@ export class ImageService {
   /**
    * 图片生成
    */
+  private resolveMiniMaxImageSize(size?: string): { aspect_ratio?: string, width?: number, height?: number } {
+    if (!size) {
+      return {}
+    }
+
+    const officialAspectRatioBySize: Record<string, string> = {
+      '1024x1024': '1:1',
+      '1280x720': '16:9',
+      '1152x864': '4:3',
+      '1248x832': '3:2',
+      '832x1248': '2:3',
+      '864x1152': '3:4',
+      '720x1280': '9:16',
+      '1344x576': '21:9',
+    }
+
+    const normalized = size.toLowerCase()
+    if (officialAspectRatioBySize[normalized]) {
+      return { aspect_ratio: officialAspectRatioBySize[normalized] }
+    }
+
+    if (/^\d+:\d+$/.test(size)) {
+      return { aspect_ratio: size }
+    }
+
+    const match = /^(\d+)x(\d+)$/i.exec(size)
+    if (!match) {
+      return {}
+    }
+
+    const width = Number(match[1])
+    const height = Number(match[2])
+    if (
+      width >= 512
+      && width <= 2048
+      && height >= 512
+      && height <= 2048
+      && width % 8 === 0
+      && height % 8 === 0
+    ) {
+      return { width, height }
+    }
+
+    return {}
+  }
+
+  private async minimaxGeneration(request: ImageGenerationDto, runtimeModel: string) {
+    if (!request.user) {
+      throw new BadRequestException('userId is required')
+    }
+
+    const result = await this.minimaxService.createImageGeneration({
+      model: runtimeModel,
+      prompt: request.prompt,
+      n: Math.min(request.n ?? 1, 9),
+      response_format: 'url',
+      prompt_optimizer: true,
+      ...this.resolveMiniMaxImageSize(request.size),
+    })
+
+    const imageUrls = result.data?.image_urls ?? result.data?.images ?? []
+    const imageBase64List = result.data?.image_base64 ?? []
+    const data: AiLogImageResult[] = []
+
+    for (const imageUrl of imageUrls) {
+      data.push({
+        url: await this.uploadImageToS3(imageUrl, request.user, `ai/images/${request.model}`),
+      })
+    }
+
+    for (const imageBase64 of imageBase64List) {
+      const buffer = Buffer.from(imageBase64, 'base64')
+      const uploadResult = await this.assetsService.uploadFromBuffer(request.user, buffer, {
+        type: AssetType.AiImage,
+        mimeType: 'image/png',
+      }, `ai/images/${request.model}`)
+      data.push({ url: uploadResult.asset.path })
+    }
+
+    return {
+      id: result.id,
+      created: Math.floor(Date.now() / 1000),
+      data,
+      list: data,
+      metadata: result.metadata,
+    }
+  }
+
   async generation(request: ImageGenerationDto) {
     const { user, ...params } = request
+    const modelConfig = this.getImageModelConfig(params.model, 'generation') as ImageGenerationModelConfig | undefined
     const runtimeModel = this.resolveRuntimeImageModel(params.model, 'generation')
 
     if (!user) {
       throw new BadRequestException('userId is required')
+    }
+
+    if (modelConfig?.channel === AiLogChannel.MiniMax) {
+      return this.minimaxGeneration(request, runtimeModel)
     }
 
     if (runtimeModel === 'gpt-image-1') {
@@ -431,11 +535,13 @@ export class ImageService {
     const { userId, userType, source = CreditsConsumptionSource.AiImage, ...params } = request
 
     const pricing = await this.getImageModelPricing(params.model, 'generation', userId, userType)
+    const channel = this.resolveImageModelChannel(params.model, 'generation')
 
     return await this.handleUserAiAction({
       userId,
       userType,
       model: params.model,
+      channel,
       type: AiLogType.Image,
       pricing,
       request: params,
@@ -487,6 +593,7 @@ export class ImageService {
   async userGenerationAsync(request: UserImageGenerationDto) {
     const { userId, userType, source = CreditsConsumptionSource.AiImage, ...params } = request
     const pricing = await this.getImageModelPricing(params.model, 'generation', userId, userType)
+    const channel = this.resolveImageModelChannel(params.model, 'generation')
 
     if (pricing > 0 && userType === UserType.User) {
       await this.deductUserCredits(userId, pricing, params.model, undefined, source)
@@ -497,7 +604,7 @@ export class ImageService {
       userId,
       userType,
       model: params.model,
-      channel: AiLogChannel.NewApi,
+      channel,
       type: AiLogType.Image,
       points: pricing,
       settlement: this.asyncSettlementService.createPendingSettlement(pricing, {
@@ -515,7 +622,7 @@ export class ImageService {
       userId,
       userType,
       model: params.model,
-      channel: AiLogChannel.NewApi,
+      channel,
       type: AiLogType.Image,
       pricing,
       request: { ...params, user: userId },

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/gemini/gemini.config.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/gemini/gemini.config.ts
@@ -23,7 +23,7 @@ export const geminiConfigSchema = z.object({
 
   // 图片生成 API 配置（单 Key）
   apiKey: z.string().describe('Gemini Image Generation API Key'),
-  baseUrl: z.string().describe('Gemini Image Generation Base URL'),
+  baseUrl: z.string().default('https://generativelanguage.googleapis.com').describe('Gemini Image Generation Base URL'),
 
   // Key 管理配置
   keyManager: geminiKeyManagerConfigSchema.optional(),

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/gemini/gemini.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/gemini/gemini.service.ts
@@ -37,13 +37,15 @@ export class GeminiService {
     private readonly config: GeminiConfig,
     readonly keyManager: GeminiKeyManagerService,
   ) {
-    const baseUrl = config.proxyUrl
-      ? `${config.proxyUrl}/${config.baseUrl}`
-      : config.baseUrl
+    const configuredBaseUrl = config.baseUrl?.trim()
+    const proxyUrl = config.proxyUrl?.trim()
+    const baseUrl = configuredBaseUrl
+      ? (proxyUrl ? `${proxyUrl}/${configuredBaseUrl}` : configuredBaseUrl)
+      : undefined
 
     this.genAiClient = new GoogleGenAI({
       apiKey: config.apiKey,
-      httpOptions: { baseUrl },
+      ...(baseUrl ? { httpOptions: { baseUrl } } : {}),
     })
   }
 

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/index.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/index.ts
@@ -1,0 +1,4 @@
+export * from './minimax.config'
+export * from './minimax.interface'
+export * from './minimax.module'
+export * from './minimax.service'

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.config.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.config.ts
@@ -1,0 +1,10 @@
+import { createZodDto } from '@yikart/common'
+import { z } from 'zod'
+
+export const minimaxConfigSchema = z.object({
+  apiKey: z.string().describe('MiniMax API Key'),
+  baseUrl: z.string().default('https://api.minimax.io').describe('MiniMax API Base URL'),
+  timeout: z.number().default(60000).describe('MiniMax API timeout in milliseconds'),
+})
+
+export class MiniMaxConfig extends createZodDto(minimaxConfigSchema) {}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.interface.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.interface.ts
@@ -1,0 +1,134 @@
+export interface MiniMaxBaseResponse {
+  status_code: number
+  status_msg: string
+}
+
+export interface MiniMaxImageGenerationRequest {
+  model: 'image-01' | 'image-01-live' | string
+  prompt: string
+  aspect_ratio?: '1:1' | '16:9' | '4:3' | '3:2' | '2:3' | '3:4' | '9:16' | '21:9' | string
+  width?: number
+  height?: number
+  response_format?: 'url' | 'base64'
+  seed?: number
+  n?: number
+  prompt_optimizer?: boolean
+  subject_reference?: Array<{
+    type: string
+    image_file: string
+  }>
+}
+
+export interface MiniMaxImageGenerationResponse {
+  id: string
+  data?: {
+    image_urls?: string[]
+    image_base64?: string[]
+    images?: string[]
+  }
+  metadata?: {
+    failed_count?: string
+    success_count?: string
+  }
+  base_resp: MiniMaxBaseResponse
+}
+
+export interface MiniMaxCreateVideoTaskRequest {
+  model: string
+  prompt?: string
+  first_frame_image?: string
+  last_frame_image?: string
+  duration?: number
+  resolution?: '512P' | '720P' | '768P' | '1080P' | string
+  prompt_optimizer?: boolean
+  fast_pretreatment?: boolean
+  callback_url?: string
+  subject_reference?: Array<{
+    type: string
+    image_file: string
+  }>
+}
+
+export interface MiniMaxCreateVideoTaskResponse {
+  task_id?: string
+  base_resp: MiniMaxBaseResponse
+}
+
+export enum MiniMaxVideoTaskStatus {
+  Preparing = 'Preparing',
+  Queueing = 'Queueing',
+  Processing = 'Processing',
+  Success = 'Success',
+  Fail = 'Fail',
+}
+
+export interface MiniMaxQueryVideoTaskResponse {
+  task_id: string
+  status: MiniMaxVideoTaskStatus
+  file_id?: string
+  video_width?: number
+  video_height?: number
+  base_resp: MiniMaxBaseResponse
+}
+
+export interface MiniMaxRetrieveFileResponse {
+  file?: {
+    file_id: string
+    bytes?: number
+    created_at?: number
+    filename?: string
+    purpose?: string
+    download_url?: string
+  }
+  base_resp: MiniMaxBaseResponse
+}
+
+export interface MiniMaxTextToSpeechRequest {
+  model: string
+  text: string
+  stream?: boolean
+  language_boost?: string
+  output_format?: 'url' | 'hex'
+  voice_setting?: Record<string, unknown>
+  audio_setting?: Record<string, unknown>
+  pronunciation_dict?: Record<string, unknown>
+  voice_modify?: Record<string, unknown>
+  subtitle_enable?: boolean
+  subtitle_type?: string
+}
+
+export interface MiniMaxTextToSpeechResponse {
+  data?: {
+    audio?: string
+    status?: number
+    subtitle_file?: string
+  } | null
+  trace_id?: string
+  extra_info?: Record<string, unknown>
+  base_resp: MiniMaxBaseResponse
+}
+
+export interface MiniMaxMusicGenerationRequest {
+  model: string
+  prompt?: string
+  lyrics?: string
+  stream?: boolean
+  output_format?: 'url' | 'hex'
+  audio_setting?: Record<string, unknown>
+  lyrics_optimizer?: boolean
+  is_instrumental?: boolean
+  audio_url?: string
+  audio_base64?: string
+  cover_feature_id?: string
+}
+
+export interface MiniMaxMusicGenerationResponse {
+  data?: {
+    audio?: string
+    status?: number
+  } | null
+  trace_id?: string
+  extra_info?: Record<string, unknown>
+  analysis_info?: unknown
+  base_resp: MiniMaxBaseResponse
+}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.module.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.module.ts
@@ -1,0 +1,21 @@
+import { DynamicModule, Module } from '@nestjs/common'
+import { MiniMaxConfig } from './minimax.config'
+import { MiniMaxService } from './minimax.service'
+
+@Module({})
+export class MiniMaxModule {
+  static forRoot(config: MiniMaxConfig): DynamicModule {
+    return {
+      global: true,
+      module: MiniMaxModule,
+      providers: [
+        {
+          provide: MiniMaxConfig,
+          useValue: config,
+        },
+        MiniMaxService,
+      ],
+      exports: [MiniMaxService],
+    }
+  }
+}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/libs/minimax/minimax.service.ts
@@ -1,0 +1,127 @@
+import { Injectable } from '@nestjs/common'
+import axios, { AxiosInstance, AxiosResponse } from 'axios'
+import { AiAvailabilityService } from '../../../ai-availability'
+import { MiniMaxConfig } from './minimax.config'
+import {
+  MiniMaxCreateVideoTaskRequest,
+  MiniMaxCreateVideoTaskResponse,
+  MiniMaxImageGenerationRequest,
+  MiniMaxImageGenerationResponse,
+  MiniMaxMusicGenerationRequest,
+  MiniMaxMusicGenerationResponse,
+  MiniMaxQueryVideoTaskResponse,
+  MiniMaxRetrieveFileResponse,
+  MiniMaxTextToSpeechRequest,
+  MiniMaxTextToSpeechResponse,
+} from './minimax.interface'
+
+@Injectable()
+export class MiniMaxService {
+  private readonly httpClient: AxiosInstance
+
+  constructor(
+    private readonly config: MiniMaxConfig,
+    private readonly aiAvailability: AiAvailabilityService,
+  ) {
+    this.httpClient = axios.create({
+      baseURL: this.config.baseUrl.replace(/\/+$/, ''),
+      timeout: this.config.timeout,
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${this.config.apiKey}`,
+      },
+    })
+  }
+
+  private assertSuccess(response: { base_resp?: { status_code?: number, status_msg?: string } }, fallback: string): void {
+    const baseResp = response.base_resp
+    if (baseResp && baseResp.status_code !== 0) {
+      throw new Error(baseResp.status_msg || `${fallback} failed with status ${baseResp.status_code}`)
+    }
+  }
+
+  async createImageGeneration(request: MiniMaxImageGenerationRequest): Promise<MiniMaxImageGenerationResponse> {
+    return this.aiAvailability.execute(
+      { provider: 'minimax', operation: 'imageGeneration', model: request.model },
+      async () => {
+        const response: AxiosResponse<MiniMaxImageGenerationResponse> = await this.httpClient.post(
+          '/v1/image_generation',
+          request,
+        )
+        this.assertSuccess(response.data, 'MiniMax image generation')
+        return response.data
+      },
+    )
+  }
+
+  async createVideoTask(request: MiniMaxCreateVideoTaskRequest): Promise<MiniMaxCreateVideoTaskResponse> {
+    return this.aiAvailability.execute(
+      { provider: 'minimax', operation: 'createVideoTask', model: request.model },
+      async () => {
+        const response: AxiosResponse<MiniMaxCreateVideoTaskResponse> = await this.httpClient.post(
+          '/v1/video_generation',
+          request,
+        )
+        this.assertSuccess(response.data, 'MiniMax video task creation')
+        return response.data
+      },
+    )
+  }
+
+  async getVideoTask(taskId: string): Promise<MiniMaxQueryVideoTaskResponse> {
+    return this.aiAvailability.execute(
+      { provider: 'minimax', operation: 'getVideoTask' },
+      async () => {
+        const response: AxiosResponse<MiniMaxQueryVideoTaskResponse> = await this.httpClient.get(
+          '/v1/query/video_generation',
+          { params: { task_id: taskId } },
+        )
+        this.assertSuccess(response.data, 'MiniMax video task query')
+        return response.data
+      },
+    )
+  }
+
+  async retrieveFile(fileId: string): Promise<MiniMaxRetrieveFileResponse> {
+    return this.aiAvailability.execute(
+      { provider: 'minimax', operation: 'retrieveFile' },
+      async () => {
+        const response: AxiosResponse<MiniMaxRetrieveFileResponse> = await this.httpClient.get(
+          '/v1/files/retrieve',
+          { params: { file_id: fileId } },
+        )
+        this.assertSuccess(response.data, 'MiniMax file retrieve')
+        return response.data
+      },
+    )
+  }
+
+  async textToSpeech(request: MiniMaxTextToSpeechRequest): Promise<MiniMaxTextToSpeechResponse> {
+    return this.aiAvailability.execute(
+      { provider: 'minimax', operation: 'textToSpeech', model: request.model },
+      async () => {
+        const response: AxiosResponse<MiniMaxTextToSpeechResponse> = await this.httpClient.post(
+          '/v1/t2a_v2',
+          request,
+        )
+        this.assertSuccess(response.data, 'MiniMax text to speech')
+        return response.data
+      },
+    )
+  }
+
+  async generateMusic(request: MiniMaxMusicGenerationRequest): Promise<MiniMaxMusicGenerationResponse> {
+    return this.aiAvailability.execute(
+      { provider: 'minimax', operation: 'musicGeneration', model: request.model },
+      async () => {
+        const response: AxiosResponse<MiniMaxMusicGenerationResponse> = await this.httpClient.post(
+          '/v1/music_generation',
+          request,
+        )
+        this.assertSuccess(response.data, 'MiniMax music generation')
+        return response.data
+      },
+    )
+  }
+}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/index.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/index.ts
@@ -1,6 +1,7 @@
 export * from './dashscope'
 export * from './gemini'
 export * from './grok'
+export * from './minimax'
 export * from './openai'
 export * from './video.controller'
 export * from './video.dto'

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/minimax/index.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/minimax/index.ts
@@ -1,0 +1,2 @@
+export * from './minimax.module'
+export * from './minimax.service'

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/minimax/minimax.module.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/minimax/minimax.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common'
+import { ModelsConfigModule } from '../../models-config'
+import { SettlementModule } from '../../settlement'
+import { MiniMaxVideoService } from './minimax.service'
+
+@Module({
+  imports: [
+    ModelsConfigModule,
+    SettlementModule,
+  ],
+  providers: [MiniMaxVideoService],
+  exports: [MiniMaxVideoService],
+})
+export class MiniMaxVideoModule {}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/minimax/minimax.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/minimax/minimax.service.ts
@@ -1,0 +1,414 @@
+import type { MiniMaxVideoAiLog } from '../video-ai-log.interface'
+import type { UserVideoGenerationRequestDto } from '../video.dto'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
+import { AiLogSettlementSettledBy } from '@yikart/aitoearn-ai-shared'
+import { QueueService } from '@yikart/aitoearn-queue'
+import { AssetsService, StorageProvider } from '@yikart/assets'
+import { AppException, CreditsConsumptionSource, CreditsType, FileUtil, ResponseCode, UserType } from '@yikart/common'
+import { CreditsHelperService } from '@yikart/helpers'
+import { AiLog, AiLogChannel, AiLogRepository, AiLogStatus, AiLogType, AssetType } from '@yikart/mongodb'
+import { TaskStatus } from '../../../../common'
+import {
+  MiniMaxCreateVideoTaskRequest,
+  MiniMaxQueryVideoTaskResponse,
+  MiniMaxService as MiniMaxLibService,
+  MiniMaxVideoTaskStatus,
+} from '../../libs/minimax'
+import { ModelsConfigService } from '../../models-config'
+import { AsyncSettlementService } from '../../settlement'
+
+export interface MiniMaxVideoCallbackDto {
+  id: string
+  status: MiniMaxVideoTaskStatus
+  providerModel?: string
+  fileId?: string
+  videoUrl?: string
+  videoWidth?: number
+  videoHeight?: number
+  error?: string
+}
+
+interface MiniMaxVideoModelConfig {
+  name: string
+  defaults: {
+    resolution?: string
+    aspectRatio?: string
+    duration?: number
+  }
+  durations: number[]
+  maxInputImages: number
+  pricing: Array<{
+    resolution?: string
+    mode?: string
+    duration?: number
+    price: number
+  }>
+  modes: string[]
+  modeMappings?: Record<string, string>
+}
+
+@Injectable()
+export class MiniMaxVideoService {
+  private readonly logger = new Logger(MiniMaxVideoService.name)
+
+  constructor(
+    private readonly minimaxLibService: MiniMaxLibService,
+    private readonly aiLogRepo: AiLogRepository,
+    private readonly assetsService: AssetsService,
+    private readonly storageProvider: StorageProvider,
+    private readonly modelsConfigService: ModelsConfigService,
+    private readonly creditsHelper: CreditsHelperService,
+    private readonly queueService: QueueService,
+    private readonly asyncSettlementService: AsyncSettlementService,
+  ) {}
+
+  private getModelConfig(model: string): MiniMaxVideoModelConfig {
+    const modelConfig = this.modelsConfigService.config.video.generation.find(m => m.name === model)
+    if (!modelConfig || modelConfig.channel !== AiLogChannel.MiniMax) {
+      throw new AppException(ResponseCode.InvalidModel)
+    }
+    return modelConfig as MiniMaxVideoModelConfig
+  }
+
+  private collectImageUrls(request: UserVideoGenerationRequestDto): string[] {
+    const imageUrls: string[] = []
+    if (request.image) {
+      if (Array.isArray(request.image)) {
+        imageUrls.push(...request.image)
+      }
+      else {
+        imageUrls.push(request.image)
+      }
+    }
+    if (request.images) {
+      imageUrls.push(...request.images)
+    }
+    return imageUrls
+  }
+
+  private resolveMode(request: UserVideoGenerationRequestDto, modelConfig: MiniMaxVideoModelConfig, imageUrls: string[]): string {
+    if (request.mode) {
+      if (!modelConfig.modes.includes(request.mode)) {
+        throw new AppException(ResponseCode.InvalidModel)
+      }
+      return request.mode
+    }
+
+    if (request.image_tail || imageUrls.length >= 2) {
+      return 'flf2video'
+    }
+
+    if (imageUrls.length === 1) {
+      return 'image2video'
+    }
+
+    return 'text2video'
+  }
+
+  private getProviderModel(modelConfig: MiniMaxVideoModelConfig, mode: string): string {
+    const providerModel = modelConfig.modeMappings?.[mode]
+    if (!providerModel) {
+      throw new AppException(ResponseCode.InvalidModel)
+    }
+    return providerModel
+  }
+
+  private getPrice(modelConfig: MiniMaxVideoModelConfig, resolution: string | undefined, duration: number | undefined, mode?: string): number {
+    const pricing = modelConfig.pricing.find(item => item.resolution === resolution
+      && item.duration === duration
+      && (mode ? item.mode === mode || !item.mode : !item.mode))
+    if (!pricing) {
+      throw new AppException(ResponseCode.InvalidModel)
+    }
+    return pricing.price
+  }
+
+  private async toAccessibleUrl(url: string): Promise<string> {
+    const parsed = this.storageProvider.parsePathFromUrl(url)
+    if (parsed.startsWith('http') || parsed.startsWith('data:')) {
+      return url
+    }
+    return this.storageProvider.toPresignedUrl(url)
+  }
+
+  private async buildPayload(request: UserVideoGenerationRequestDto, modelConfig: MiniMaxVideoModelConfig): Promise<{
+    providerModel: string
+    mode: string
+    payload: MiniMaxCreateVideoTaskRequest
+    duration?: number
+    resolution?: string
+    firstFrameImage?: string
+    lastFrameImage?: string
+  }> {
+    if (request.video_url || request.videos?.length || request.audios?.length) {
+      throw new BadRequestException('MiniMax video generation only supports text/image inputs')
+    }
+
+    const imageUrls = this.collectImageUrls(request)
+    const mode = this.resolveMode(request, modelConfig, imageUrls)
+    if (!modelConfig.modes.includes(mode)) {
+      throw new AppException(ResponseCode.InvalidModel)
+    }
+    if (imageUrls.length > modelConfig.maxInputImages) {
+      throw new AppException(ResponseCode.InvalidModel)
+    }
+
+    const providerModel = this.getProviderModel(modelConfig, mode)
+    const duration = request.duration ?? modelConfig.defaults.duration
+    const resolution = request.resolution ?? modelConfig.defaults.resolution
+    const payload: MiniMaxCreateVideoTaskRequest = {
+      model: providerModel,
+      prompt: request.prompt,
+      duration,
+      resolution,
+    }
+
+    let firstFrameImage: string | undefined
+    let lastFrameImage: string | undefined
+    if (mode === 'image2video' || mode === 'flf2video') {
+      firstFrameImage = imageUrls[0]
+      if (!firstFrameImage) {
+        throw new BadRequestException('MiniMax image-to-video requires an image')
+      }
+      payload.first_frame_image = await this.toAccessibleUrl(firstFrameImage)
+    }
+
+    if (mode === 'flf2video') {
+      lastFrameImage = request.image_tail ?? imageUrls[1]
+      if (!lastFrameImage) {
+        throw new BadRequestException('MiniMax first-last-frame video requires image_tail or two images')
+      }
+      payload.last_frame_image = await this.toAccessibleUrl(lastFrameImage)
+    }
+
+    if (request.metadata?.['promptOptimizer'] != null) {
+      payload.prompt_optimizer = Boolean(request.metadata['promptOptimizer'])
+    }
+    if (request.metadata?.['fastPretreatment'] != null) {
+      payload.fast_pretreatment = Boolean(request.metadata['fastPretreatment'])
+    }
+
+    return {
+      providerModel,
+      mode,
+      payload,
+      duration,
+      resolution,
+      firstFrameImage,
+      lastFrameImage,
+    }
+  }
+
+  calculatePrice(params: { model: string, resolution?: string, duration?: number, mode?: string }): number {
+    const modelConfig = this.getModelConfig(params.model)
+    const resolution = params.resolution ?? modelConfig.defaults.resolution
+    const duration = params.duration ?? modelConfig.defaults.duration
+    return this.getPrice(modelConfig, resolution, duration, params.mode)
+  }
+
+  async createFromRequest(request: UserVideoGenerationRequestDto): Promise<{ id: string, points: number }> {
+    const modelConfig = this.getModelConfig(request.model)
+    const source = request.source ?? CreditsConsumptionSource.AiVideo
+    const { providerModel, mode, payload, duration, resolution, firstFrameImage, lastFrameImage } = await this.buildPayload(request, modelConfig)
+    const pricing = this.getPrice(modelConfig, resolution, duration, mode)
+    const startedAt = new Date()
+    const result = await this.minimaxLibService.createVideoTask(payload)
+    const taskId = result.task_id
+    if (!taskId) {
+      throw new BadRequestException(result.base_resp?.status_msg || 'MiniMax task id is missing')
+    }
+
+    if (request.userType === UserType.User) {
+      await this.creditsHelper.deductCredits({
+        userId: request.userId,
+        amount: pricing,
+        type: CreditsType.AiService,
+        source,
+        description: request.model,
+      })
+    }
+
+    const aiLog = await this.aiLogRepo.create({
+      userId: request.userId,
+      userType: request.userType,
+      taskId,
+      model: request.model,
+      channel: AiLogChannel.MiniMax,
+      startedAt,
+      type: AiLogType.Video,
+      points: pricing,
+      settlement: this.asyncSettlementService.createPendingSettlement(pricing, { source }),
+      request: {
+        model: request.model,
+        providerModel,
+        mode,
+        prompt: request.prompt,
+        image: firstFrameImage,
+        imageTail: lastFrameImage,
+        resolution,
+        duration,
+        promptOptimizer: payload.prompt_optimizer,
+        fastPretreatment: payload.fast_pretreatment,
+        groupId: request.groupId,
+      },
+      response: {
+        id: taskId,
+        status: MiniMaxVideoTaskStatus.Preparing,
+        providerModel,
+      },
+      status: AiLogStatus.Generating,
+    })
+
+    return { id: aiLog.id, points: pricing }
+  }
+
+  private async enqueueTaskRefund(aiLog: AiLog): Promise<void> {
+    await this.asyncSettlementService.markFailed(aiLog.id, {
+      channel: aiLog.channel,
+      action: aiLog.action,
+      settledBy: AiLogSettlementSettledBy.MiniMaxCallback,
+    })
+
+    if (aiLog.userType !== UserType.User) {
+      return
+    }
+
+    await this.queueService.addAiTaskRefundJob({
+      userId: aiLog.userId,
+      taskId: aiLog.id,
+      amount: aiLog.points,
+      description: aiLog.model,
+      expiredAt: null,
+      metadata: {
+        channel: aiLog.channel,
+        action: aiLog.action,
+        failedAt: new Date().toISOString(),
+      },
+    })
+  }
+
+  private async failTask(aiLog: MiniMaxVideoAiLog, taskId: string, errorMessage: string, elapsedMs: number, status = MiniMaxVideoTaskStatus.Fail): Promise<MiniMaxVideoCallbackDto> {
+    const callbackData: MiniMaxVideoCallbackDto = {
+      id: taskId,
+      status,
+      providerModel: aiLog.request.providerModel,
+      error: errorMessage,
+    }
+
+    await this.aiLogRepo.updateById(aiLog.id, {
+      status: AiLogStatus.Failed,
+      response: callbackData,
+      duration: elapsedMs,
+      errorMessage,
+    })
+
+    await this.enqueueTaskRefund(aiLog)
+    return callbackData
+  }
+
+  private normalizeDownloadUrl(url: string): string {
+    if (/^https?:\/\//i.test(url)) {
+      return url
+    }
+    return `https://${url}`
+  }
+
+  async callback(queryResult: MiniMaxQueryVideoTaskResponse): Promise<MiniMaxVideoCallbackDto> {
+    const taskId = queryResult.task_id
+    const aiLog = await this.aiLogRepo.getByTaskId(taskId)
+    if (!aiLog || aiLog.channel !== AiLogChannel.MiniMax) {
+      throw new AppException(ResponseCode.InvalidAiTaskId)
+    }
+    const minimaxAiLog = aiLog as MiniMaxVideoAiLog
+
+    if (minimaxAiLog.status !== AiLogStatus.Generating) {
+      return minimaxAiLog.response!
+    }
+
+    const status = queryResult.status
+    if (
+      status === MiniMaxVideoTaskStatus.Preparing
+      || status === MiniMaxVideoTaskStatus.Queueing
+      || status === MiniMaxVideoTaskStatus.Processing
+    ) {
+      return {
+        id: taskId,
+        status,
+        providerModel: minimaxAiLog.request.providerModel,
+        fileId: queryResult.file_id,
+        videoWidth: queryResult.video_width,
+        videoHeight: queryResult.video_height,
+      }
+    }
+
+    const elapsedMs = Date.now() - minimaxAiLog.startedAt.getTime()
+    if (status === MiniMaxVideoTaskStatus.Success && queryResult.file_id) {
+      const fileResult = await this.minimaxLibService.retrieveFile(queryResult.file_id)
+      const downloadUrl = fileResult.file?.download_url
+      if (!downloadUrl) {
+        return this.failTask(minimaxAiLog, taskId, 'MiniMax task succeeded but no download URL returned', elapsedMs)
+      }
+
+      const uploaded = await this.assetsService.uploadFromUrl(minimaxAiLog.userId, {
+        url: this.normalizeDownloadUrl(downloadUrl),
+        type: AssetType.AiVideo,
+      }, minimaxAiLog.model)
+
+      const callbackData: MiniMaxVideoCallbackDto = {
+        id: taskId,
+        status,
+        providerModel: minimaxAiLog.request.providerModel,
+        fileId: queryResult.file_id,
+        videoUrl: uploaded.asset.path,
+        videoWidth: queryResult.video_width,
+        videoHeight: queryResult.video_height,
+      }
+
+      await this.aiLogRepo.updateById(minimaxAiLog.id, {
+        status: AiLogStatus.Success,
+        response: callbackData,
+        duration: elapsedMs,
+      })
+
+      await this.asyncSettlementService.settleSuccess(minimaxAiLog.id, minimaxAiLog.points, {
+        channel: minimaxAiLog.channel,
+        settledBy: AiLogSettlementSettledBy.MiniMaxCallback,
+      })
+
+      return callbackData
+    }
+
+    const errorMessage = status === MiniMaxVideoTaskStatus.Success
+      ? 'MiniMax task succeeded but no file ID returned'
+      : `MiniMax task ${status}`
+    return this.failTask(minimaxAiLog, taskId, errorMessage, elapsedMs, status)
+  }
+
+  getTaskResult(result: MiniMaxVideoCallbackDto) {
+    const status = {
+      [MiniMaxVideoTaskStatus.Success]: TaskStatus.Success,
+      [MiniMaxVideoTaskStatus.Fail]: TaskStatus.Failure,
+      [MiniMaxVideoTaskStatus.Preparing]: TaskStatus.InProgress,
+      [MiniMaxVideoTaskStatus.Queueing]: TaskStatus.InProgress,
+      [MiniMaxVideoTaskStatus.Processing]: TaskStatus.InProgress,
+    }[result.status]
+
+    return {
+      status,
+      videoUrl: result.videoUrl ? FileUtil.buildUrl(result.videoUrl) : undefined,
+      error: result.error ? { message: result.error } : undefined,
+    }
+  }
+
+  extractInput(request: MiniMaxVideoAiLog['request']) {
+    const image = request.imageTail
+      ? [request.image, request.imageTail].filter((item): item is string => Boolean(item))
+      : request.image
+    return {
+      prompt: request.prompt || '',
+      image,
+      duration: request.duration,
+      resolution: request.resolution,
+    }
+  }
+}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video-ai-log.interface.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video-ai-log.interface.ts
@@ -2,6 +2,7 @@ import type {
   DashscopeVideoAiLogRequest,
   GeminiVideoAiLogRequest,
   GrokVideoAiLogRequest,
+  MiniMaxVideoAiLogRequest,
   OpenAIRemixVideoAiLogRequest,
   OpenAIVideoAiLogRequest,
   TypedAiLog,
@@ -11,6 +12,7 @@ import type {
 import type { DashscopeVideoCallbackDto } from './dashscope'
 import type { GeminiVeoVideoCallbackDto } from './gemini/gemini.dto'
 import type { GrokVideoCallbackDto } from './grok/grok.service'
+import type { MiniMaxVideoCallbackDto } from './minimax'
 import type { OpenAIVideoCallbackDto } from './openai/openai.dto'
 import type { VolcengineCallbackDto } from './volcengine/volcengine.dto'
 import { AiLogChannel, AiLogType } from '@yikart/mongodb'
@@ -53,6 +55,12 @@ export type GeminiVideoAiLog = VideoAiLogBase & {
   response?: GeminiVeoVideoCallbackDto & SavedVideoMediaInfo
 }
 
+export type MiniMaxVideoAiLog = VideoAiLogBase & {
+  channel: AiLogChannel.MiniMax
+  request: MiniMaxVideoAiLogRequest
+  response?: MiniMaxVideoCallbackDto & SavedVideoMediaInfo
+}
+
 export type UserRequestedVideoAiLog = VideoAiLogBase & {
   request: UserVideoGenerationAiLogRequest
 }
@@ -63,6 +71,7 @@ export interface VideoAiLogByChannelMap {
   [AiLogChannel.Grok]: GrokVideoAiLog
   [AiLogChannel.Dashscope]: DashscopeVideoAiLog
   [AiLogChannel.Gemini]: GeminiVideoAiLog
+  [AiLogChannel.MiniMax]: MiniMaxVideoAiLog
 }
 
 export type VideoAiLogByChannel<C extends keyof VideoAiLogByChannelMap> = VideoAiLogByChannelMap[C]
@@ -73,3 +82,4 @@ export type VideoAiLog
     | GrokVideoAiLog
     | DashscopeVideoAiLog
     | GeminiVideoAiLog
+    | MiniMaxVideoAiLog

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video-task-status.scheduler.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video-task-status.scheduler.ts
@@ -9,11 +9,13 @@ import { RedlockKey } from '../../../common'
 import { DashscopeService as DashscopeLibService } from '../libs/dashscope'
 import { GeminiService } from '../libs/gemini'
 import { GrokLibService, GrokVideoTaskStatus } from '../libs/grok'
+import { MiniMaxService as MiniMaxLibService } from '../libs/minimax'
 import { OpenaiService } from '../libs/openai'
 import { VolcengineService } from '../libs/volcengine'
 import { DashscopeVideoService } from './dashscope'
 import { GeminiVideoService } from './gemini'
 import { GrokVideoService } from './grok'
+import { MiniMaxVideoService } from './minimax'
 import { OpenAIVideoService } from './openai'
 import { VideoService } from './video.service'
 import { VolcengineVideoService } from './volcengine'
@@ -34,6 +36,8 @@ export class VideoTaskStatusScheduler {
     private readonly grokVideoService: GrokVideoService,
     private readonly dashscopeLibService: DashscopeLibService,
     private readonly dashscopeVideoService: DashscopeVideoService,
+    private readonly minimaxLibService: MiniMaxLibService,
+    private readonly minimaxVideoService: MiniMaxVideoService,
     private readonly videoService: VideoService,
   ) { }
 
@@ -110,6 +114,10 @@ export class VideoTaskStatusScheduler {
     else if (channel === AiLogChannel.Dashscope) {
       const result = await this.dashscopeLibService.getVideoTask(taskId)
       await this.dashscopeVideoService.callback(result)
+    }
+    else if (channel === AiLogChannel.MiniMax) {
+      const result = await this.minimaxLibService.getVideoTask(taskId)
+      await this.minimaxVideoService.callback(result)
     }
     else {
       this.logger.warn(`任务 ${task.id} 未知的 channel: ${channel}，跳过检查`)

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video.module.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video.module.ts
@@ -3,6 +3,7 @@ import { ModelsConfigModule } from '../models-config'
 import { DashscopeVideoModule } from './dashscope'
 import { GeminiVideoModule } from './gemini'
 import { GrokVideoModule } from './grok'
+import { MiniMaxVideoModule } from './minimax'
 import { OpenAIVideoModule } from './openai'
 import { VideoTaskStatusScheduler } from './video-task-status.scheduler'
 import { VideoController } from './video.controller'
@@ -17,9 +18,10 @@ import { VolcengineVideoModule } from './volcengine'
     GeminiVideoModule,
     GrokVideoModule,
     DashscopeVideoModule,
+    MiniMaxVideoModule,
   ],
   controllers: [VideoController],
   providers: [VideoService, VideoTaskStatusScheduler],
-  exports: [VideoService, VolcengineVideoModule, OpenAIVideoModule, GeminiVideoModule, GrokVideoModule, DashscopeVideoModule],
+  exports: [VideoService, VolcengineVideoModule, OpenAIVideoModule, GeminiVideoModule, GrokVideoModule, DashscopeVideoModule, MiniMaxVideoModule],
 })
 export class VideoModule {}

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/ai/video/video.service.ts
@@ -17,6 +17,7 @@ import { ModelsConfigService } from '../models-config'
 import { DashscopeVideoService } from './dashscope'
 import { GeminiVideoService } from './gemini'
 import { GrokVideoService } from './grok'
+import { MiniMaxVideoService } from './minimax'
 import { OpenAIVideoService } from './openai'
 import { VideoAiLog } from './video-ai-log.interface'
 import {
@@ -45,6 +46,7 @@ export class VideoService {
     private readonly grokVideoService: GrokVideoService,
     private readonly geminiVideoService: GeminiVideoService,
     private readonly dashscopeVideoService: DashscopeVideoService,
+    private readonly minimaxVideoService: MiniMaxVideoService,
   ) {}
 
   async calculateVideoGenerationPrice(params: {
@@ -72,6 +74,8 @@ export class VideoService {
         return this.geminiVideoService.calculatePrice(params)
       case AiLogChannel.Dashscope:
         return this.dashscopeVideoService.calculatePrice(params)
+      case AiLogChannel.MiniMax:
+        return this.minimaxVideoService.calculatePrice(params)
       default:
         throw new AppException(ResponseCode.InvalidModel)
     }
@@ -110,6 +114,9 @@ export class VideoService {
       case AiLogChannel.Dashscope:
         response = await this.dashscopeVideoService.createFromRequest(request)
         break
+      case AiLogChannel.MiniMax:
+        response = await this.minimaxVideoService.createFromRequest(request)
+        break
       default:
         throw new AppException(ResponseCode.InvalidModel)
     }
@@ -146,6 +153,9 @@ export class VideoService {
         break
       case AiLogChannel.Dashscope:
         input = this.dashscopeVideoService.extractInput(aiLog.request)
+        break
+      case AiLogChannel.MiniMax:
+        input = this.minimaxVideoService.extractInput(aiLog.request)
         break
       default:
         input = { prompt: '' }
@@ -215,6 +225,7 @@ export class VideoService {
       case AiLogChannel.Grok:
       case AiLogChannel.Gemini:
       case AiLogChannel.Dashscope:
+      case AiLogChannel.MiniMax:
         await this.ensureSavedVideoMedia(aiLog as VideoAiLog)
     }
   }
@@ -235,6 +246,8 @@ export class VideoService {
         return this.geminiVideoService.getTaskResult(aiLog.response)
       case AiLogChannel.Dashscope:
         return this.dashscopeVideoService.getTaskResult(aiLog.response)
+      case AiLogChannel.MiniMax:
+        return this.minimaxVideoService.getTaskResult(aiLog.response)
       default:
         throw new AppException(ResponseCode.InvalidAiTaskId)
     }
@@ -258,6 +271,7 @@ export class VideoService {
       case AiLogChannel.Grok:
       case AiLogChannel.Gemini:
       case AiLogChannel.Dashscope:
+      case AiLogChannel.MiniMax:
         return this.transformToCommonResponse(aiLog as VideoAiLog)
       default:
         throw new AppException(ResponseCode.InvalidAiTaskId)
@@ -278,6 +292,7 @@ export class VideoService {
           case AiLogChannel.Grok:
           case AiLogChannel.Gemini:
           case AiLogChannel.Dashscope:
+          case AiLogChannel.MiniMax:
             return this.transformToCommonResponse(log as VideoAiLog)
           default:
             throw new AppException(ResponseCode.InvalidAiTaskId)

--- a/project/aitoearn-backend/apps/aitoearn-ai/src/core/draft-generation/draft-generation.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-ai/src/core/draft-generation/draft-generation.service.ts
@@ -375,7 +375,7 @@ export class DraftGenerationService {
     if (generationModel) {
       return {
         mode: 'openai-generation',
-        channel: AiLogChannel.NewApi,
+        channel: (generationModel as { channel?: AiLogChannel }).channel ?? AiLogChannel.NewApi,
         referenceHandling: referenceImageUrls.length > 0 ? ImageExecutionReferenceHandling.Ignored : ImageExecutionReferenceHandling.None,
         resolvedSize,
       }

--- a/project/aitoearn-backend/libs/aitoearn-ai-shared/src/enums/ai-log.enum.ts
+++ b/project/aitoearn-backend/libs/aitoearn-ai-shared/src/enums/ai-log.enum.ts
@@ -51,6 +51,7 @@ export enum AiLogSettlementSettledBy {
   GeminiCallback = 'gemini-callback',
   VolcengineCallback = 'volcengine-callback',
   DashscopeCallback = 'dashscope-callback',
+  MiniMaxCallback = 'minimax-callback',
   AiTaskRefundQueue = 'ai-task-refund-queue',
   ImageAsyncConsumer = 'image-async-consumer',
 }
@@ -74,4 +75,5 @@ export enum AiLogChannel {
   Anthropic = 'anthropic',
   Gemini = 'gemini',
   Grok = 'grok',
+  MiniMax = 'minimax',
 }

--- a/project/aitoearn-backend/libs/aitoearn-ai-shared/src/vos/image.vo.ts
+++ b/project/aitoearn-backend/libs/aitoearn-ai-shared/src/vos/image.vo.ts
@@ -1,6 +1,6 @@
 import { createZodDto, zodI18nString } from '@yikart/common'
 import { z } from 'zod'
-import { AiLogStatus } from '../enums'
+import { AiLogChannel, AiLogStatus } from '../enums'
 
 // 使用情况统计
 const usageMetadataSchema = z.object({
@@ -37,6 +37,7 @@ export const imageGenerationModelSchema = z.object({
   logo: z.string().optional(),
   tags: z.array(zodI18nString()).default([]),
   mainTag: z.string().optional(),
+  channel: z.enum(AiLogChannel).optional(),
   sizes: z.array(z.string()).describe('支持的尺寸'),
   qualities: z.array(z.string()).describe('支持的质量选项'),
   styles: z.array(z.string()).describe('支持的风格选项'),

--- a/project/aitoearn-backend/libs/mongodb/src/schemas/ai-log.schema.ts
+++ b/project/aitoearn-backend/libs/mongodb/src/schemas/ai-log.schema.ts
@@ -208,6 +208,20 @@ export type GeminiVideoAiLogRequest = AiLogObject<{
   groupId?: string
 }>
 
+export type MiniMaxVideoAiLogRequest = AiLogObject<{
+  model: string
+  providerModel?: string
+  mode?: string
+  prompt: string
+  image?: string
+  imageTail?: string
+  duration?: number
+  resolution?: string
+  promptOptimizer?: boolean
+  fastPretreatment?: boolean
+  groupId?: string
+}>
+
 export type VideoAiLogRequest
   = | UserVideoGenerationAiLogRequest
     | VolcengineVideoAiLogRequest
@@ -216,6 +230,7 @@ export type VideoAiLogRequest
     | GrokVideoAiLogRequest
     | DashscopeVideoAiLogRequest
     | GeminiVideoAiLogRequest
+    | MiniMaxVideoAiLogRequest
 
 export type VideoAiLogResponse = AiLogObject<{
   id?: string

--- a/project/aitoearn-backend/scripts/build-docker.mjs
+++ b/project/aitoearn-backend/scripts/build-docker.mjs
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
 import { arch } from 'node:os'
+import { pathToFileURL } from 'node:url'
 import { Command } from 'commander'
 import { $, chalk, fs, path } from 'zx'
+
+if (process.platform === 'win32') {
+  $.shell = 'powershell.exe'
+  $.prefix = ''
+}
 
 function getDefaultPlatform() {
   const a = arch()
@@ -387,7 +393,7 @@ async function generateConfig(projects, graph, contextDir, verbose = false) {
     console.info(chalk.green('Monorepo 配置生成完成'))
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const program = new Command()
 
   program

--- a/project/aitoearn-web/Dockerfile
+++ b/project/aitoearn-web/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV=production
 
 RUN apk add --no-cache libc6-compat
 
-RUN corepack enable pnpm && corepack prepare pnpm@latest --activate
+RUN corepack enable pnpm && corepack prepare pnpm@9.15.9 --activate
 
 WORKDIR /app
 

--- a/project/aitoearn-web/src/app/[lng]/ai-social/components/PromptGallery/components/VideoDetailModal.tsx
+++ b/project/aitoearn-web/src/app/[lng]/ai-social/components/PromptGallery/components/VideoDetailModal.tsx
@@ -63,24 +63,24 @@ const ModalContent = memo(({ onOpenChange, item, onApplyPrompt }: ModalContentPr
 
   return (
     <Dialog open onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[90vh] w-[min(900px,95vw)] flex-col overflow-hidden p-0">
-        <DialogHeader className="shrink-0 border-b px-4 py-3 sm:px-6 sm:py-4">
-          <DialogTitle>{item.title}</DialogTitle>
+      <DialogContent className="flex max-h-[calc(100dvh-24px)] w-[calc(100vw-24px)] max-w-[900px] flex-col overflow-hidden p-0 sm:max-h-[calc(100dvh-48px)] sm:w-[calc(100vw-48px)]">
+        <DialogHeader className="shrink-0 border-b px-4 py-3 pr-12 sm:px-6 sm:py-4 sm:pr-14">
+          <DialogTitle className="break-words leading-snug">{item.title}</DialogTitle>
         </DialogHeader>
 
         {/* 内容区域：移动端上下布局，PC 左右布局 */}
-        <div className={cn('flex min-h-0 flex-1 flex-col overflow-hidden sm:flex-row')}>
+        <div className={cn('flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden sm:flex-row')}>
           {/* 左侧/上方：视频播放 */}
           <div
             className={cn(
-              'shrink-0 sm:w-1/2 sm:shrink',
+              'min-h-0 min-w-0 shrink-0 sm:basis-1/2 sm:shrink',
               'flex items-center justify-center',
               'bg-gradient-to-br from-muted/50 to-muted',
               'p-1 sm:p-2',
               'max-h-[40vh] sm:max-h-none',
             )}
           >
-            <div className="relative w-full sm:h-full max-h-[40vh] sm:max-h-[calc(90vh-120px)] overflow-hidden rounded-lg shadow-lg">
+            <div className="relative flex max-h-[40vh] min-h-0 w-full min-w-0 items-center justify-center overflow-hidden rounded-lg shadow-lg sm:h-full sm:max-h-[calc(100dvh-168px)]">
               <video
                 src={item.video}
                 poster={item.cover}
@@ -94,7 +94,7 @@ const ModalContent = memo(({ onOpenChange, item, onApplyPrompt }: ModalContentPr
           </div>
 
           {/* 右侧/下方：提示词内容 */}
-          <div className={cn('flex min-h-0 flex-col flex-1 overflow-hidden', 'sm:w-1/2')}>
+          <div className={cn('flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden', 'sm:basis-1/2')}>
             {/* 提示词标签和复制按钮 - 固定高度 */}
             <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
               <span className="text-sm font-medium text-muted-foreground">


### PR DESCRIPTION
## Summary

This PR adds a MiniMax media provider to AiToEarn's AI service, wires it into image/video generation flows, and documents the required deployment configuration.

## Changes

- Add a reusable MiniMax API client for image generation, video task creation/querying, file retrieval, text-to-speech, and music generation endpoints.
- Wire MiniMax image generation into the existing image service, including URL/base64 asset ingestion and `AiLogChannel.MiniMax` attribution.
- Add MiniMax video generation support for Hailuo 2.3 and Hailuo 2.3 Fast, including task creation, scheduler polling, file retrieval, asset upload, success settlement, and failure refund handling.
- Register MiniMax model configuration for `MiniMax-M3`, `minimax-image-01`, `minimax-hailuo-2.3`, and `minimax-hailuo-2.3-fast`.
- Extend the Agent `generateImage` MCP tool so text-to-image defaults to `minimax-image-01`, while reference-image workflows continue to use Gemini image models.
- Add a safe Gemini image base URL fallback so an empty `GEMINI_BASE_URL` placeholder no longer causes `TypeError: Invalid URL` in the Google GenAI SDK.
- Allow MiniMax-compatible `OPENAI_BASE_URL` deployments to reuse existing OpenAI-style configuration when `MINIMAX_API_KEY` is not separately provided.
- Document MiniMax environment variables and built-in models in both Chinese and English Docker deployment guides.
- Include two local deployment fixes found while validating the stack: pin the web Dockerfile pnpm version and keep the prompt gallery detail modal within the viewport.

## Security / secrets

No local secret files are included. The staged diff was scanned for token-like values before commit and did not contain API keys, authorization headers, or bearer tokens.

## Validation

- `pnpm exec nx build aitoearn-ai --outputStyle=static`
- `pnpm exec vitest run src/core/agent/mcp/media.mcp.spec.ts` with a temporary local test config and placeholder environment values
- `git diff --cached --check`
- staged secret-pattern scan: no matches
- local Docker image rebuilt and `aitoearn-ai` container verified healthy

## Notes

The MiniMax client includes speech and music methods, but this PR only wires the existing image and video product flows because the current app does not expose speech/music business entry points yet.