### PR TITLE
feat(channels): nurture state machine + LLM intent classifier for Engage Agent

### DIFF
--- a/project/aitoearn-backend/apps/aitoearn-server/src/common/redis/server-redis-keys.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/common/redis/server-redis-keys.ts
@@ -46,4 +46,13 @@ export class ServerRedisKeys {
   static douyinOpenTicket(): string {
     return 'douyin:open_ticket'
   }
+
+  static nurtureAccountState(accountId: string): string {
+    return `nurture:account:${accountId}`
+  }
+
+
+  static nurtureDailyCount(accountId: string): string {
+    return `nurture:daily_count:${accountId}`
+  }
 }

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/channels.module.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/channels.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common'
 import { AccountGroupService } from './accounts/account-group.service'
+import { NurtureModule } from './nurture/nurture.module'
 import { AccountGroupsController } from './accounts/account-groups.controller'
 import { AccountService } from './accounts/account.service'
 import { AccountsController } from './accounts/accounts.controller'
@@ -34,7 +35,7 @@ import { WorkService } from './works/work.service'
 import { WorksController } from './works/works.controller'
 
 @Module({
-  imports: [PlatformsModule, MediaModule],
+  imports: [PlatformsModule, MediaModule, NurtureModule.register()],
   controllers: [
     AccountsController,
     AccountGroupsController,

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/engagement/engagement.service.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/engagement/engagement.service.ts
@@ -1,4 +1,7 @@
 import type { AccountType } from '@yikart/common'
+import { IntentClassifier, IntentLevel, NurtureStage, NurtureStateMachine } from '../nurture'
+import { ServerRedisKeys, ServerRedisService } from '../../common/redis'
+
 import type {
   ChannelPaginationInput,
   CredentialContext,
@@ -33,6 +36,8 @@ export class EngagementService {
     private readonly registry: PlatformIntegrationRegistry,
     private readonly authService: AuthService,
     private readonly accountRepository: AccountRepository,
+    private readonly intentClassifier: IntentClassifier,
+    private readonly redis: ServerRedisService,
   ) {}
 
   async listComments(
@@ -324,6 +329,101 @@ export class EngagementService {
     catch (error) {
       await this.authService.markAccountOfflineForCredentialFailure(accountId, error, 'platform_auth_failed')
       throw error
+    }
+  }
+
+
+  // ═══════════════════════════════════════════════════════════
+  // 养号状态机集成
+  // ═══════════════════════════════════════════════════════════
+
+  /**
+   * 获取或初始化账户的养号上下文
+   * 从 Redis 读取状态，不存在则创建默认 COLD 状态
+   */
+  private async getNurtureContext(accountId: string, platform: AccountType): Promise<{
+    context: {
+      accountId: string
+      platform: AccountType
+      registeredAt: Date
+      currentStage: string
+      todayCounts: { publish: number; engagement: number; comments: number }
+    }
+    isNew: boolean
+  }> {
+    const stateKey = ServerRedisKeys.nurtureAccountState(accountId)
+    const cached = await this.redis.getChannelAuthSession<any>(stateKey)
+
+    const now = new Date()
+    const registeredAt = cached?.registeredAt ? new Date(cached.registeredAt) : now
+
+    const ctx = {
+      accountId,
+      platform,
+      registeredAt,
+      currentStage: cached?.currentStage ?? NurtureStateMachine.inferStage(registeredAt),
+      todayCounts: cached?.todayCounts ?? { publish: 0, engagement: 0, comments: 0 },
+    }
+
+    // 如果是新账户（无缓存），初始化为 COLD
+    const isNew = !cached
+    if (isNew) {
+      ctx.currentStage = NurtureStage.COLD
+      ctx.registeredAt = now
+    }
+
+    return { context: ctx, isNew }
+  }
+
+  /**
+   * 检查评论动作是否受养号状态机允许
+   */
+  private async checkNurtureForComment(
+    accountId: string,
+    platform: AccountType,
+  ): Promise<{ allowed: boolean; reason?: string; stage: string }> {
+    const { context } = await this.getNurtureContext(accountId, platform)
+
+    const result = NurtureStateMachine.checkAction(context as any, 'comment')
+    if (!result.allowed) {
+      return { allowed: false, reason: result.reason, stage: result.stage }
+    }
+
+    return { allowed: true, stage: result.stage }
+  }
+
+  /**
+   * 保存养号上下文到 Redis
+   */
+  private async saveNurtureContext(
+    accountId: string,
+    context: {
+      registeredAt: Date
+      currentStage: string
+      todayCounts: { publish: number; engagement: number; comments: number }
+    },
+  ): Promise<void> {
+    const stateKey = ServerRedisKeys.nurtureAccountState(accountId)
+    await this.redis.saveChannelAuthSession(stateKey, context, 60 * 60 * 24) // 24h TTL
+  }
+
+  /**
+   * LLM 意图分类：判断评论是否值得回复
+   * 高意向 → 走私信触发；中意向 → 仅回评；无效 → 忽略
+   */
+  private async classifyCommentIntent(comment: string): Promise<{
+    level: IntentLevel
+    confidence: number
+    shouldReply: boolean
+    shouldDm: boolean
+  }> {
+    const classification = await this.intentClassifier.classify(comment)
+
+    return {
+      level: classification.level,
+      confidence: classification.confidence,
+      shouldReply: classification.level !== IntentLevel.INVALID,
+      shouldDm: classification.level === IntentLevel.HIGH,
     }
   }
 }

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/account-state.spec.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/account-state.spec.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NurtureStage,
+  STAGE_CONFIGS,
+  NurtureStateMachine,
+  type NurtureContext,
+  type AllowedAction,
+} from './account-state'
+
+// ─── 辅助函数 ────────────────────────────────────────────────
+
+function createMockContext(
+  daysAgo: number,
+  currentStage?: NurtureStage,
+  todayCounts?: NurtureContext['todayCounts'],
+): NurtureContext {
+  const registeredAt = new Date()
+  registeredAt.setDate(registeredAt.getDate() - daysAgo)
+
+  return {
+    accountId: 'test-account',
+    platform: 'douyin' as any,
+    registeredAt,
+    currentStage: currentStage ?? NurtureStateMachine.inferStage(registeredAt),
+    todayCounts: todayCounts ?? { publish: 0, engagement: 0, comments: 0 },
+  }
+}
+
+// ─── 阶段推断测试 ────────────────────────────────────────────
+
+describe('NurtureStateMachine.inferStage', () => {
+  it('COLD 阶段：注册 0-3 天', () => {
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 0 * 86400000))).toBe(NurtureStage.COLD)
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 1 * 86400000))).toBe(NurtureStage.COLD)
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 3 * 86400000))).toBe(NurtureStage.COLD)
+  })
+
+  it('WARM 阶段：注册 4-7 天', () => {
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 4 * 86400000))).toBe(NurtureStage.WARM)
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 7 * 86400000))).toBe(NurtureStage.WARM)
+  })
+
+  it('HOT 阶段：注册 8-14 天', () => {
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 8 * 86400000))).toBe(NurtureStage.HOT)
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 14 * 86400000))).toBe(NurtureStage.HOT)
+  })
+
+  it('ACTIVE 阶段：注册 15 天以上', () => {
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 15 * 86400000))).toBe(NurtureStage.ACTIVE)
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 30 * 86400000))).toBe(NurtureStage.ACTIVE)
+    expect(NurtureStateMachine.inferStage(new Date(Date.now() - 365 * 86400000))).toBe(NurtureStage.ACTIVE)
+  })
+})
+
+// ─── 配置表测试 ──────────────────────────────────────────────
+
+describe('STAGE_CONFIGS', () => {
+  it('COLD 阶段禁止发布', () => {
+    const config = STAGE_CONFIGS[NurtureStage.COLD]
+    expect(config.maxDailyPublish).toBe(0)
+    expect(config.allowedActions).not.toContain('publish')
+  })
+
+  it('WARM 阶段允许每日 1 条发布', () => {
+    const config = STAGE_CONFIGS[NurtureStage.WARM]
+    expect(config.maxDailyPublish).toBe(1)
+    expect(config.allowedActions).toContain('publish')
+  })
+
+  it('HOT 阶段允许私信', () => {
+    const config = STAGE_CONFIGS[NurtureStage.HOT]
+    expect(config.allowedActions).toContain('dm')
+  })
+
+  it('ACTIVE 阶段拥有全部动作权限', () => {
+    const config = STAGE_CONFIGS[NurtureStage.ACTIVE]
+    expect(config.allowedActions).toContain('share')
+    expect(config.maxDailyPublish).toBe(5)
+  })
+
+  it('所有阶段都允许浏览', () => {
+    for (const stage of Object.values(NurtureStage)) {
+      expect(STAGE_CONFIGS[stage].allowedActions).toContain('browse')
+    }
+  })
+})
+
+// ─── 动作检查测试 ────────────────────────────────────────────
+
+describe('NurtureStateMachine.checkAction', () => {
+  it('COLD 阶段禁止发布', () => {
+    const ctx = createMockContext(2)
+    const result = NurtureStateMachine.checkAction(ctx, 'publish')
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('不允许')
+  })
+
+  it('COLD 阶段允许浏览', () => {
+    const ctx = createMockContext(2)
+    const result = NurtureStateMachine.checkAction(ctx, 'browse')
+    expect(result.allowed).toBe(true)
+  })
+
+  it('COLD 阶段允许点赞', () => {
+    const ctx = createMockContext(2)
+    const result = NurtureStateMachine.checkAction(ctx, 'like')
+    expect(result.allowed).toBe(true)
+  })
+
+  it('WARM 阶段允许发布（配额内）', () => {
+    const ctx = createMockContext(5)
+    const result = NurtureStateMachine.checkAction(ctx, 'publish')
+    expect(result.allowed).toBe(true)
+  })
+
+  it('WARM 阶段发布配额用完后禁止', () => {
+    const ctx = createMockContext(5, undefined, { publish: 1, engagement: 0, comments: 0 })
+    const result = NurtureStateMachine.checkAction(ctx, 'publish')
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('配额已用完')
+  })
+
+  it('评论配额用完后禁止评论', () => {
+    const ctx = createMockContext(5, undefined, { publish: 0, engagement: 0, comments: 5 })
+    const result = NurtureStateMachine.checkAction(ctx, 'comment')
+    expect(result.allowed).toBe(false)
+  })
+
+  it('未知动作被拒绝', () => {
+    const ctx = createMockContext(2)
+    const result = NurtureStateMachine.checkAction(ctx, 'share' as AllowedAction)
+    expect(result.allowed).toBe(false)
+  })
+})
+
+// ─── 配额消耗测试 ────────────────────────────────────────────
+
+describe('NurtureStateMachine.consume', () => {
+  it('发布动作只增加 publish 计数', () => {
+    const ctx = createMockContext(5)
+    NurtureStateMachine.consume(ctx, 'publish')
+    expect(ctx.todayCounts.publish).toBe(1)
+    expect(ctx.todayCounts.engagement).toBe(0)
+  })
+
+  it('评论动作同时增加 comments 和 engagement 计数', () => {
+    const ctx = createMockContext(5)
+    NurtureStateMachine.consume(ctx, 'comment')
+    expect(ctx.todayCounts.comments).toBe(1)
+    expect(ctx.todayCounts.engagement).toBe(1)
+  })
+
+  it('点赞动作只增加 engagement 计数', () => {
+    const ctx = createMockContext(5)
+    NurtureStateMachine.consume(ctx, 'like')
+    expect(ctx.todayCounts.engagement).toBe(1)
+    expect(ctx.todayCounts.publish).toBe(0)
+    expect(ctx.todayCounts.comments).toBe(0)
+  })
+})
+
+// ─── 状态转移测试 ────────────────────────────────────────────
+
+describe('NurtureStateMachine.tryTransition', () => {
+  it('COLD → WARM：注册满 4 天且当前处于 COLD', () => {
+    // 注册 4 天时 inferStage 已经是 WARM，所以手动设置为 COLD 来测试转移
+    const registeredAt = new Date()
+    registeredAt.setDate(registeredAt.getDate() - 4)
+    const ctx: NurtureContext = {
+      accountId: 'test',
+      platform: 'douyin' as any,
+      registeredAt,
+      currentStage: NurtureStage.COLD, // 手动设为 COLD 模拟未更新的场景
+      todayCounts: { publish: 0, engagement: 0, comments: 0 },
+    }
+    const result = NurtureStateMachine.tryTransition(ctx)
+    expect(result.transitioned).toBe(true)
+    expect(result.newStage).toBe(NurtureStage.WARM)
+    expect(ctx.currentStage).toBe(NurtureStage.WARM)
+  })
+
+  it('WARM → HOT：注册满 8 天且当前处于 WARM', () => {
+    const registeredAt = new Date()
+    registeredAt.setDate(registeredAt.getDate() - 8)
+    const ctx: NurtureContext = {
+      accountId: 'test',
+      platform: 'douyin' as any,
+      registeredAt,
+      currentStage: NurtureStage.WARM,
+      todayCounts: { publish: 0, engagement: 0, comments: 0 },
+    }
+    const result = NurtureStateMachine.tryTransition(ctx)
+    expect(result.transitioned).toBe(true)
+    expect(result.newStage).toBe(NurtureStage.HOT)
+  })
+
+  it('HOT → ACTIVE：注册满 15 天且当前处于 HOT', () => {
+    const registeredAt = new Date()
+    registeredAt.setDate(registeredAt.getDate() - 15)
+    const ctx: NurtureContext = {
+      accountId: 'test',
+      platform: 'douyin' as any,
+      registeredAt,
+      currentStage: NurtureStage.HOT,
+      todayCounts: { publish: 0, engagement: 0, comments: 0 },
+    }
+    const result = NurtureStateMachine.tryTransition(ctx)
+    expect(result.transitioned).toBe(true)
+    expect(result.newStage).toBe(NurtureStage.ACTIVE)
+  })
+
+  it('已在 ACTIVE 不会重复转移', () => {
+    const ctx = createMockContext(30)
+    const result = NurtureStateMachine.tryTransition(ctx)
+    expect(result.transitioned).toBe(false)
+    expect(result.newStage).toBe(NurtureStage.ACTIVE)
+  })
+
+  it('转移后记录 lastTransitionAt', () => {
+    const registeredAt = new Date()
+    registeredAt.setDate(registeredAt.getDate() - 4)
+    const ctx: NurtureContext = {
+      accountId: 'test',
+      platform: 'douyin' as any,
+      registeredAt,
+      currentStage: NurtureStage.COLD,
+      todayCounts: { publish: 0, engagement: 0, comments: 0 },
+    }
+    NurtureStateMachine.tryTransition(ctx)
+    expect(ctx.lastTransitionAt).toBeDefined()
+    expect(ctx.lastTransitionAt).toBeInstanceOf(Date)
+  })
+
+  it('未到转移天数时不转移', () => {
+    const ctx = createMockContext(2) // 注册 2 天，仍在 COLD
+    const result = NurtureStateMachine.tryTransition(ctx)
+    expect(result.transitioned).toBe(false)
+    expect(result.newStage).toBe(NurtureStage.COLD)
+  })
+})
+
+// ─── 每日重置测试 ────────────────────────────────────────────
+
+describe('NurtureStateMachine.resetDailyCounts', () => {
+  it('将所有计数重置为 0', () => {
+    const ctx = createMockContext(5)
+    ctx.todayCounts = { publish: 1, engagement: 3, comments: 2 }
+    NurtureStateMachine.resetDailyCounts(ctx)
+    expect(ctx.todayCounts).toEqual({ publish: 0, engagement: 0, comments: 0 })
+  })
+})
+
+// ─── 剩余配额测试 ────────────────────────────────────────────
+
+describe('ActionResult.remainingQuota', () => {
+  it('COLD 阶段评论配额剩余正确', () => {
+    const ctx = createMockContext(2)
+    const result = NurtureStateMachine.checkAction(ctx, 'comment')
+    expect(result.allowed).toBe(true)
+    expect(result.remainingQuota.comments).toBe(5)
+  })
+
+  it('WARM 阶段发布配额扣减正确', () => {
+    const ctx = createMockContext(5, undefined, { publish: 1, engagement: 0, comments: 0 })
+    const result = NurtureStateMachine.checkAction(ctx, 'publish')
+    expect(result.allowed).toBe(false)
+    expect(result.remainingQuota.publish).toBe(0)
+  })
+})

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/account-state.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/account-state.ts
@@ -1,0 +1,273 @@
+import { AccountType } from '@yikart/common'
+
+// ─── 枚举定义 ───────────────────────────────────────────────
+
+export enum NurtureStage {
+  /** 1-3天：只刷不发，建立基础活跃 */
+  COLD = 'COLD',
+  /** 4-7天：每日1-2次轻量互动（点赞/简单评论） */
+  WARM = 'WARM',
+  /** 8-14天：进入正常发布节奏 */
+  HOT = 'HOT',
+  /** 15天+：稳定运营期 */
+  ACTIVE = 'ACTIVE',
+}
+
+// ─── 配置接口 ───────────────────────────────────────────────
+
+export interface StageConfig {
+  /** 阶段名称 */
+  stage: NurtureStage
+  /** 最低天数（距首次注册时间） */
+  minDays: number
+  /** 最高天数（含），超过则自动进入下一阶段 */
+  maxDays: number
+  /** 每日发布上限（0=禁止发布） */
+  maxDailyPublish: number
+  /** 每日互动上限（点赞+评论+关注等） */
+  maxDailyEngagement: number
+  /** 每日评论上限 */
+  maxDailyComments: number
+  /** 允许执行的动作集合 */
+  allowedActions: AllowedAction[]
+}
+
+export type AllowedAction =
+  | 'browse'          // 浏览内容
+  | 'like'            // 点赞
+  | 'comment'         // 评论
+  | 'reply'           // 回复评论
+  | 'bookmark'        // 收藏
+  | 'follow'          // 关注
+  | 'publish'         // 发布作品
+  | 'dm'              // 发送私信
+  | 'share'           // 分享
+
+// ─── 动作结果 ───────────────────────────────────────────────
+
+export interface ActionResult {
+  /** 动作是否被允许 */
+  allowed: boolean
+  /** 如果禁止，原因说明 */
+  reason?: string
+  /** 当前阶段 */
+  stage: NurtureStage
+  /** 当日剩余配额 */
+  remainingQuota: {
+    publish: number
+    engagement: number
+    comments: number
+  }
+}
+
+// ─── 状态上下文 ─────────────────────────────────────────────
+
+export interface NurtureContext {
+  /** 账户 ID */
+  accountId: string
+  /** 平台类型 */
+  platform: AccountType
+  /** 首次注册/激活日期 */
+  registeredAt: Date
+  /** 上次状态转移时间 */
+  lastTransitionAt?: Date
+  /** 当前所处阶段 */
+  currentStage: NurtureStage
+  /** 当日已执行动作计数 */
+  todayCounts: {
+    publish: number
+    engagement: number
+    comments: number
+  }
+}
+
+// ─── 默认配置表 ─────────────────────────────────────────────
+
+export const STAGE_CONFIGS: Record<NurtureStage, StageConfig> = {
+  [NurtureStage.COLD]: {
+    stage: NurtureStage.COLD,
+    minDays: 1,
+    maxDays: 3,
+    maxDailyPublish: 0,        // 禁止发布
+    maxDailyEngagement: 20,     // 可浏览+轻度互动
+    maxDailyComments: 5,
+    allowedActions: ['browse', 'like', 'comment', 'reply', 'bookmark', 'follow'],
+  },
+  [NurtureStage.WARM]: {
+    stage: NurtureStage.WARM,
+    minDays: 4,
+    maxDays: 7,
+    maxDailyPublish: 1,         // 每天最多1条
+    maxDailyEngagement: 15,
+    maxDailyComments: 5,
+    allowedActions: ['browse', 'like', 'comment', 'reply', 'bookmark', 'follow', 'publish'],
+  },
+  [NurtureStage.HOT]: {
+    stage: NurtureStage.HOT,
+    minDays: 8,
+    maxDays: 14,
+    maxDailyPublish: 3,         // 逐步增加到3条
+    maxDailyEngagement: 10,
+    maxDailyComments: 3,
+    allowedActions: ['browse', 'like', 'comment', 'reply', 'bookmark', 'follow', 'publish', 'dm'],
+  },
+  [NurtureStage.ACTIVE]: {
+    stage: NurtureStage.ACTIVE,
+    minDays: 15,
+    maxDays: Infinity,
+    maxDailyPublish: 5,         // 稳定期最高5条
+    maxDailyEngagement: 10,
+    maxDailyComments: 5,
+    allowedActions: ['browse', 'like', 'comment', 'reply', 'bookmark', 'follow', 'publish', 'dm', 'share'],
+  },
+}
+
+// ─── 核心服务类 ─────────────────────────────────────────────
+
+export class NurtureStateMachine {
+  /** 计算两个日期之间的天数差 */
+  static daysSince(date: Date): number {
+    const now = new Date()
+    const diff = now.getTime() - date.getTime()
+    return Math.floor(diff / (1000 * 60 * 60 * 24))
+  }
+
+  /** 根据注册天数推断当前阶段 */
+  static inferStage(registeredAt: Date): NurtureStage {
+    const days = this.daysSince(registeredAt)
+    if (days >= 15) return NurtureStage.ACTIVE
+    if (days >= 8) return NurtureStage.HOT
+    if (days >= 4) return NurtureStage.WARM
+    return NurtureStage.COLD
+  }
+
+  /** 获取某个阶段的配置 */
+  static getConfig(stage: NurtureStage): StageConfig {
+    return STAGE_CONFIGS[stage]
+  }
+
+  /** 检查某动作在当前状态下是否允许 */
+  static checkAction(
+    context: NurtureContext,
+    action: AllowedAction,
+  ): ActionResult {
+    const config = STAGE_CONFIGS[context.currentStage]
+
+    // 1. 动作是否在允许列表中
+    if (!config.allowedActions.includes(action)) {
+      return {
+        allowed: false,
+        reason: `${context.currentStage}阶段不允许执行「${action}」动作`,
+        stage: context.currentStage,
+        remainingQuota: {
+          publish: config.maxDailyPublish - context.todayCounts.publish,
+          engagement: config.maxDailyEngagement - context.todayCounts.engagement,
+          comments: config.maxDailyComments - context.todayCounts.comments,
+        },
+      }
+    }
+
+    // 2. 检查发布配额
+    if (action === 'publish') {
+      const remaining = config.maxDailyPublish - context.todayCounts.publish
+      if (remaining <= 0) {
+        return {
+          allowed: false,
+          reason: `今日发布配额已用完（${config.maxDailyPublish}/${config.maxDailyPublish}）`,
+          stage: context.currentStage,
+          remainingQuota: {
+            publish: 0,
+            engagement: config.maxDailyEngagement - context.todayCounts.engagement,
+            comments: config.maxDailyComments - context.todayCounts.comments,
+          },
+        }
+      }
+    }
+
+    // 3. 检查评论配额
+    if (action === 'comment' || action === 'reply') {
+      const remaining = config.maxDailyComments - context.todayCounts.comments
+      if (remaining <= 0) {
+        return {
+          allowed: false,
+          reason: `今日评论配额已用完（${config.maxDailyComments}/${config.maxDailyComments}）`,
+          stage: context.currentStage,
+          remainingQuota: {
+            publish: config.maxDailyPublish - context.todayCounts.publish,
+            engagement: config.maxDailyEngagement - context.todayCounts.engagement,
+            comments: 0,
+          },
+        }
+      }
+    }
+
+    // 4. 检查互动总配额
+    if (action !== 'publish' && action !== 'comment' && action !== 'reply') {
+      const remaining = config.maxDailyEngagement - context.todayCounts.engagement
+      if (remaining <= 0) {
+        return {
+          allowed: false,
+          reason: `今日互动配额已用完（${config.maxDailyEngagement}/${config.maxDailyEngagement}）`,
+          stage: context.currentStage,
+          remainingQuota: {
+            publish: config.maxDailyPublish - context.todayCounts.publish,
+            engagement: 0,
+            comments: config.maxDailyComments - context.todayCounts.comments,
+          },
+        }
+      }
+    }
+
+    // 通过所有检查
+    return {
+      allowed: true,
+      stage: context.currentStage,
+      remainingQuota: {
+        publish: config.maxDailyPublish - context.todayCounts.publish,
+        engagement: config.maxDailyEngagement - context.todayCounts.engagement,
+        comments: config.maxDailyComments - context.todayCounts.comments,
+      },
+    }
+  }
+
+  /** 执行动作后扣减配额 */
+  static consume(context: NurtureContext, action: AllowedAction): void {
+    if (action === 'publish') {
+      context.todayCounts.publish += 1
+    } else if (action === 'comment' || action === 'reply') {
+      context.todayCounts.comments += 1
+      context.todayCounts.engagement += 1
+    } else {
+      context.todayCounts.engagement += 1
+    }
+  }
+
+  /** 尝试转移阶段（每日调度时调用） */
+  static tryTransition(context: NurtureContext): { transitioned: boolean; newStage: NurtureStage } {
+    const days = this.daysSince(context.registeredAt)
+    let newStage: NurtureStage
+
+    if (days >= 15) newStage = NurtureStage.ACTIVE
+    else if (days >= 8) newStage = NurtureStage.HOT
+    else if (days >= 4) newStage = NurtureStage.WARM
+    else newStage = NurtureStage.COLD
+
+    if (newStage !== context.currentStage) {
+      const prevStage = context.currentStage
+      context.currentStage = newStage
+      context.lastTransitionAt = new Date()
+      return { transitioned: true, newStage }
+    }
+
+    return { transitioned: false, newStage: context.currentStage }
+  }
+
+  /** 重置当日计数（每日零点调用） */
+  static resetDailyCounts(context: NurtureContext): void {
+    context.todayCounts = {
+      publish: 0,
+      engagement: 0,
+      comments: 0,
+    }
+  }
+}

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/index.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/index.ts
@@ -1,0 +1,17 @@
+export {
+  NurtureStage,
+  STAGE_CONFIGS,
+  AllowedAction,
+  StageConfig,
+  ActionResult,
+  NurtureContext,
+  NurtureStateMachine,
+} from './account-state'
+
+export {
+  IntentLevel,
+  IntentClassification,
+  IntentClassifier,
+} from './intent-classifier'
+
+export { NurtureModule } from './nurture.module'

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/intent-classifier.spec.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/intent-classifier.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fastMatch, IntentLevel, type IntentClassification } from './intent-classifier'
+
+// 注意：fastMatch 是模块内部的私有函数，我们通过导出它来测试
+// 在 intent-classifier.ts 中已将 fastMatch 导出
+
+describe('IntentClassifier - 快速规则匹配', () => {
+  describe('高意向关键词匹配', () => {
+    it('单条高意向关键词 → HIGH', () => {
+      const result = fastMatch('这个多少钱？')
+      expect(result?.level).toBe(IntentLevel.HIGH)
+      expect(result?.confidence).toBe(0.75)
+    })
+
+    it('多条高意向关键词 → HIGH（高置信度）', () => {
+      const result = fastMatch('怎么买？多少钱？')
+      expect(result?.level).toBe(IntentLevel.HIGH)
+      expect(result?.confidence).toBe(0.95)
+    })
+
+    it('英文高意向关键词', () => {
+      const result = fastMatch('how much is this?')
+      expect(result?.level).toBe(IntentLevel.HIGH)
+    })
+  })
+
+  describe('无效/Spam 关键词匹配', () => {
+    it('关注互粉 → INVALID', () => {
+      const result = fastMatch('关注互粉啊')
+      expect(result?.level).toBe(IntentLevel.INVALID)
+      expect(result?.confidence).toBe(0.85)
+    })
+
+    it('广告推广 → INVALID', () => {
+      const result = fastMatch('加微信领取免费资料')
+      expect(result?.level).toBe(IntentLevel.INVALID)
+    })
+
+    it('辱骂内容 → INVALID', () => {
+      const result = fastMatch('傻逼产品，垃圾')
+      expect(result?.level).toBe(IntentLevel.INVALID)
+    })
+  })
+
+  describe('无法匹配 → null（需要 LLM）', () => {
+    it('普通赞美评论', () => {
+      const result = fastMatch('视频做得真好！')
+      expect(result).toBeNull()
+    })
+
+    it('中性提问', () => {
+      const result = fastMatch('这个是怎么实现的？')
+      expect(result).toBeNull()
+    })
+
+    it('空字符串', () => {
+      const result = fastMatch('')
+      expect(result).toBeNull()
+    })
+
+    it('纯表情', () => {
+      const result = fastMatch('👍')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('边界情况', () => {
+    it('中英文混合', () => {
+      const result = fastMatch('这个 how much？')
+      expect(result?.level).toBe(IntentLevel.HIGH)
+    })
+
+    it('大小写不敏感', () => {
+      const result = fastMatch('HOW MUCH?')
+      expect(result?.level).toBe(IntentLevel.HIGH)
+    })
+
+    it('长文本中包含关键词', () => {
+      const result = fastMatch('大家好，我想问一下这个产品的价格和购买链接，谢谢！')
+      expect(result?.level).toBe(IntentLevel.HIGH)
+      expect(result?.confidence).toBe(0.95)
+    })
+  })
+})
+
+describe('IntentClassification 结构', () => {
+  it('返回的对象包含必需字段', () => {
+    const result: IntentClassification | null = fastMatch('多少钱')
+    expect(result).not.toBeNull()
+    expect(result).toHaveProperty('level')
+    expect(result).toHaveProperty('confidence')
+    expect(result).toHaveProperty('reason')
+    // entities 是可选的
+  })
+
+  it('confidence 在 0-1 范围内', () => {
+    const result = fastMatch('多少钱')
+    expect(result?.confidence).toBeGreaterThanOrEqual(0)
+    expect(result?.confidence).toBeLessThanOrEqual(1)
+  })
+})

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/intent-classifier.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/intent-classifier.ts
@@ -1,0 +1,177 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { AppException, ResponseCode } from '@yikart/common'
+import axios, { AxiosInstance } from 'axios'
+import { AitoearnAiClientConfig } from '@yikart/aitoearn-ai-client'
+
+// ─── 意图分类结果 ────────────────────────────────────────────
+
+export enum IntentLevel {
+  /** 高意向：明确询问价格、购买方式、联系方式 */
+  HIGH = 'HIGH',
+  /** 中意向：表达兴趣、了解更多、比较产品 */
+  MEDIUM = 'MEDIUM',
+  /** 无效/噪音：广告、 spam、无关内容 */
+  INVALID = 'INVALID',
+}
+
+export interface IntentClassification {
+  /** 意图等级 */
+  level: IntentLevel
+  /** 置信度 0-1 */
+  confidence: number
+  /** 分类理由 */
+  reason: string
+  /** 提取的关键实体（如价格、产品名） */
+  entities?: Record<string, string>
+}
+
+// ─── Prompt 模板 ────────────────────────────────────────────
+
+const CLASSIFICATION_PROMPT = `你是一个社交媒体评论意图分类器。请分析以下评论内容，判断评论者的购买意向等级。
+
+评论者意图分为三个等级：
+- HIGH（高意向）：明确询问价格、怎么买、在哪里买、有没有优惠、联系方式等
+- MEDIUM（中意向）：表达兴趣、觉得不错、想了解更多、和其他产品比较等
+- INVALID（无效）：广告推广、spam、辱骂、无关内容、纯表情等
+
+请严格按以下 JSON 格式返回，不要包含任何其他内容：
+{
+  "level": "HIGH|MEDIUM|INVALID",
+  "confidence": 0.0-1.0,
+  "reason": "简短的分类理由",
+  "entities": {"实体名": "实体值"}
+}
+
+评论内容：'''{{COMMENT}}'''`
+
+// ─── 内置规则引擎（快速过滤，不调用 LLM） ─────────────────────
+
+const HIGH_INTENT_KEYWORDS = [
+  '多少钱', '价格', '怎么买', '哪里买', '购买', '链接', '下单',
+  '优惠', '折扣', '促销', '联系方式', '电话', '私聊',
+  '报价', '多少钱一个', '团购', '批发', '代理', '加盟',
+  'how much', 'buy', 'link', 'price', 'discount', 'deal',
+]
+
+const INVALID_KEYWORDS = [
+  '关注', '互粉', '点赞', '转发', '抽奖', '免费送', '加微信',
+  '广告', '推广', '刷屏', '垃圾', '傻逼', '滚蛋', '呵呵',
+  'follow', 'like', 'rt', 'spam', 'scam',
+]
+
+export function fastMatch(comment: string): IntentClassification | null {
+  const lower = comment.toLowerCase()
+
+  // 优先检查无效/Spam（即使包含高意向关键词也优先判定为无效）
+  const invalidHits = INVALID_KEYWORDS.filter(kw => lower.includes(kw)).length
+  if (invalidHits >= 1) {
+    return { level: IntentLevel.INVALID, confidence: 0.85, reason: '无效/spam 关键词匹配' }
+  }
+
+  // 高意向关键词命中 ≥ 2 个 → 直接判定 HIGH
+  const highHits = HIGH_INTENT_KEYWORDS.filter(kw => lower.includes(kw)).length
+  if (highHits >= 2) {
+    return { level: IntentLevel.HIGH, confidence: 0.95, reason: '多条高意向关键词匹配' }
+  }
+  if (highHits === 1) {
+    return { level: IntentLevel.HIGH, confidence: 0.75, reason: '单条高意向关键词匹配' }
+  }
+
+  return null
+}
+
+// ─── LLM 意图分类器服务 ──────────────────────────────────────
+
+@Injectable()
+export class IntentClassifier {
+  private readonly logger = new Logger(IntentClassifier.name)
+  private readonly httpClient: AxiosInstance
+  private readonly model: string
+
+  constructor(private readonly aiConfig: AitoearnAiClientConfig) {
+    this.httpClient = axios.create({
+      baseURL: this.aiConfig.baseUrl,
+      timeout: 15000,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.aiConfig.token}`,
+      },
+    })
+    this.model = this.aiConfig.model ?? 'gpt-4o-mini'
+  }
+
+  /**
+   * 对评论进行意图分类
+   * 流程：先走内置规则快速过滤，无法确定时再调 LLM
+   */
+  async classify(comment: string): Promise<IntentClassification> {
+    // Step 1: 快速规则匹配
+    const fastResult = fastMatch(comment)
+    if (fastResult) {
+      return fastResult
+    }
+
+    // Step 2: 调用 LLM 做精细分类
+    try {
+      return await this.classifyWithLLM(comment)
+    }
+    catch (err) {
+      this.logger.warn(`LLM 意图分类失败，降级为 MEDIUM: ${(err as Error).message}`)
+      // 降级策略：LLM 不可用时，保守返回 MEDIUM
+      return {
+        level: IntentLevel.MEDIUM,
+        confidence: 0.5,
+        reason: 'LLM 调用失败，降级为中意向',
+      }
+    }
+  }
+
+  /** 批量分类 */
+  async classifyBatch(comments: string[]): Promise<Map<string, IntentClassification>> {
+    const results = new Map<string, IntentClassification>()
+    for (const comment of comments) {
+      results.set(comment, await this.classify(comment))
+    }
+    return results
+  }
+
+  private async classifyWithLLM(comment: string): Promise<IntentClassification> {
+    const prompt = CLASSIFICATION_PROMPT.replace('{{COMMENT}}', comment)
+
+    const response = await this.httpClient.post('/internal/ai/chat', {
+      messages: [
+        { role: 'system' as const, content: '你是一个专业的社交媒体评论意图分析助手。请严格按要求的 JSON 格式回复。' },
+        { role: 'user' as const, content: prompt },
+      ],
+      model: this.model,
+      temperature: 0,
+      maxTokens: 500,
+    })
+
+    const data = response.data
+    // 兼容 aitoearn-ai 的 CommonResponse 包装
+    const content = data?.data?.choices?.[0]?.message?.content
+      ?? data?.choices?.[0]?.message?.content
+      ?? (data as any)?.content
+
+    if (!content) {
+      throw new AppException(ResponseCode.AiServiceUnavailable, 'LLM 意图分类返回空响应')
+    }
+
+    // 解析 JSON 响应
+    const jsonMatch = content.match(/\{[\s\S]*\}/)
+    if (!jsonMatch) {
+      throw new AppException(ResponseCode.AiServiceUnavailable, `LLM 返回非 JSON 格式: ${content.slice(0, 100)}`)
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]) as IntentClassification
+
+    // 校验字段
+    if (!Object.values(IntentLevel).includes(parsed.level)) {
+      parsed.level = IntentLevel.MEDIUM
+    }
+    parsed.confidence = Math.max(0, Math.min(1, parsed.confidence ?? 0.5))
+
+    return parsed
+  }
+}

--- a/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/nurture.module.ts
+++ b/project/aitoearn-backend/apps/aitoearn-server/src/core/channels/nurture/nurture.module.ts
@@ -1,0 +1,24 @@
+import { DynamicModule, Module } from '@nestjs/common'
+import { AitoearnAiClientConfig } from '@yikart/aitoearn-ai-client'
+import { IntentClassifier } from './intent-classifier'
+
+/**
+ * 养号状态机模块
+ * 提供 IntentClassifier（评论意图分类），供 EngagementService 调用
+ */
+@Module({})
+export class NurtureModule {
+  static register(): DynamicModule {
+    return {
+      module: NurtureModule,
+      providers: [
+        {
+          provide: IntentClassifier,
+          useFactory: (config: AitoearnAiClientConfig) => new IntentClassifier(config),
+          inject: [AitoearnAiClientConfig],
+        },
+      ],
+      exports: [IntentClassifier],
+    }
+  }
+}


### PR DESCRIPTION
## 变更概述

基于 OPTIMIZATION_PLAN.md 第②项，在 Engage Agent 中新增养号状态机 + LLM 意图分类模块。

## 新增文件

### core/nurture/ 模块
- **account-state.ts** — 养号状态机核心：COLD→WARM→HOT→ACTIVE 四阶段状态管理
- **intent-classifier.ts** — 评论意图分类器：内置规则引擎 + LLM 兜底
- **nurture.module.ts** — NestJS 模块注册
- **index.ts** — 统一导出

### 测试
- **account-state.spec.ts** — 28 个测试：阶段推断、配置表、动作检查、配额消耗、状态转移、每日重置
- **intent-classifier.spec.ts** — 15 个测试：高/低/无效关键词匹配、边界情况

**共 43 个测试全部通过 ✅**

## 集成改动

- channels.module.ts — 导入 NurtureModule.register()
- engagement.service.ts — 构造函数注入 IntentClassifier + ServerRedisService
- server-redis-keys.ts — 新增 nurture 相关 Redis key

## 状态机设计

```
COLD (1-3天) → WARM (4-7天) → HOT (8-14天) → ACTIVE (15天+)
  - 禁止发布    每日1条     每日3条     每日5条
  - 20互动/日   15互动/日   10互动/日   10互动/日
  - 5评论/日    5评论/日    3评论/日    5评论/日
```

## 意图分类设计

```
评论 → 内置规则快速匹配 → 无法确定 → LLM 精细分类
  ├── HIGH (高意向) → 触发私信
  ├── MEDIUM (中意向) → 仅回评
  └── INVALID (无效) → 忽略
```

## 验证

- vitest — 43/43 通过
- tsc --noEmit — 无新增编译错误